### PR TITLE
blog-section-improve: Make entire blog card clickable

### DIFF
--- a/src/components/BlogPreview.tsx
+++ b/src/components/BlogPreview.tsx
@@ -51,9 +51,12 @@ export function BlogPreview() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
           {blogPosts.map((post, index) => (
-            <article
+            <a
               key={index}
-              className="group bg-white dark:bg-gray-800 rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 dark:border-gray-700 hover:border-purple-200 dark:hover:border-purple-800 hover:-translate-y-2"
+              href={post.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block bg-white dark:bg-gray-800 rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 dark:border-gray-700 hover:border-purple-200 dark:hover:border-purple-800 hover:-translate-y-2 cursor-pointer"
             >
               {/* Gradient Header */}
               <div className={`h-2 bg-gradient-to-r ${
@@ -92,20 +95,15 @@ export function BlogPreview() {
                   <span>{post.readTime}</span>
                 </div>
 
-                {/* Read More Link */}
-                <a
-                  href={post.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center text-purple-600 dark:text-purple-400 font-semibold hover:text-purple-700 dark:hover:text-purple-300 transition-colors group/link"
-                >
+                {/* Read More Indicator */}
+                <div className="inline-flex items-center text-purple-600 dark:text-purple-400 font-semibold group-hover:text-purple-700 dark:group-hover:text-purple-300 transition-colors">
                   Read on Medium
-                  <svg className="w-4 h-4 ml-2 group-hover/link:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
                   </svg>
-                </a>
+                </div>
               </div>
-            </article>
+            </a>
           ))}
         </div>
 


### PR DESCRIPTION
- Convert article wrapper to clickable link element
- Maintain all existing design and hover effects
- Change nested link to visual indicator to avoid invalid HTML
- Improve user experience with larger click target area