### PR TITLE
Rebrand: founder-focused Next.js portfolio redesign

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,166 +2,1482 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-  html {
-    scroll-behavior: smooth;
-  }
+/* ============================================================
+   Portfolio — design tokens (founder-focused rebrand)
+   ============================================================ */
+:root {
+  /* Neutrals — deep cool near-black with violet tint */
+  --bg: oklch(14% 0.012 270);
+  --bg-elev: oklch(17% 0.014 270);
+  --bg-card: oklch(19% 0.015 270);
+  --bg-card-hi: oklch(22% 0.017 270);
+  --border: oklch(28% 0.018 270);
+  --border-hi: oklch(36% 0.025 270);
+  --border-soft: oklch(24% 0.015 270);
 
-  body {
-    @apply bg-white dark:bg-gray-900 text-gray-900 dark:text-white;
-    transition: background-color 0.3s ease, color 0.3s ease;
-  }
+  /* Text */
+  --fg: oklch(96% 0.005 270);
+  --fg-mute: oklch(72% 0.012 270);
+  --fg-dim: oklch(55% 0.012 270);
+  --fg-faint: oklch(40% 0.012 270);
 
-  * {
-    transition-property: background-color, border-color, color, fill, stroke;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 300ms;
-  }
+  /* Accents */
+  --accent: #b794ff;
+  --accent-hi: #d4baff;
+  --accent-soft: rgba(183, 148, 255, 0.14);
+  --accent-line: rgba(183, 148, 255, 0.32);
+  --accent-glow: rgba(183, 148, 255, 0.35);
+
+  --green: #4ade80;
+  --green-soft: rgba(74, 222, 128, 0.12);
+  --amber: #fbbf24;
+  --amber-soft: rgba(251, 191, 36, 0.12);
+  --blue: #60a5fa;
+  --blue-soft: rgba(96, 165, 250, 0.12);
+  --red: #f87171;
+  --red-soft: rgba(248, 113, 113, 0.12);
+
+  --font-sans: "Geist", "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "Geist Mono", "JetBrains Mono", ui-monospace, monospace;
+
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 20px;
+
+  --max: 1240px;
+  --pad-x: clamp(20px, 5vw, 56px);
 }
 
-@layer components {
-  .card {
-    @apply bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-100 dark:border-gray-700 transition-all duration-300;
-  }
-
-  .btn-primary {
-    @apply px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-xl font-semibold hover:shadow-xl transition-all duration-300 hover:scale-105;
-  }
-
-  .container-max-width {
-    @apply container mx-auto max-w-7xl;
-  }
-
-  .section-padding {
-    @apply px-4 sm:px-6 lg:px-8;
-  }
+/* Reset + base */
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg) !important;
+  color: var(--fg) !important;
+  font-family: var(--font-sans) !important;
+  font-feature-settings: "ss01", "cv11";
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
-@layer utilities {
-  /* Gradient Animation */
-  @keyframes gradient {
-    0%, 100% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
-  }
-
-  .animate-gradient {
-    background-size: 200% 200%;
-    animation: gradient 3s ease infinite;
-  }
-
-  /* Blob Animation */
-  @keyframes blob {
-    0%, 100% {
-      transform: translate(0, 0) scale(1);
-    }
-    25% {
-      transform: translate(20px, -50px) scale(1.1);
-    }
-    50% {
-      transform: translate(-20px, 20px) scale(0.9);
-    }
-    75% {
-      transform: translate(50px, 50px) scale(1.05);
-    }
-  }
-
-  .animate-blob {
-    animation: blob 7s infinite;
-  }
-
-  .animation-delay-2000 {
-    animation-delay: 2s;
-  }
-
-  .animation-delay-4000 {
-    animation-delay: 4s;
-  }
-
-  /* Shimmer Effect */
-  @keyframes shimmer {
-    0% {
-      transform: translateX(-100%);
-    }
-    100% {
-      transform: translateX(100%);
-    }
-  }
-
-  .animate-shimmer {
-    animation: shimmer 2s infinite;
-  }
-
-  /* Fade In Up */
-  @keyframes fadeInUp {
-    from {
-      opacity: 0;
-      transform: translateY(30px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  .animate-fadeInUp {
-    animation: fadeInUp 0.6s ease-out;
-  }
-
-  /* Float Animation */
-  @keyframes float {
-    0%, 100% {
-      transform: translateY(0);
-    }
-    50% {
-      transform: translateY(-10px);
-    }
-  }
-
-  .animate-float {
-    animation: float 3s ease-in-out infinite;
-  }
-
-  /* Pulse Glow */
-  @keyframes pulseGlow {
-    0%, 100% {
-      box-shadow: 0 0 20px rgba(168, 85, 247, 0.4);
-    }
-    50% {
-      box-shadow: 0 0 40px rgba(168, 85, 247, 0.8);
-    }
-  }
-
-  .animate-pulse-glow {
-    animation: pulseGlow 2s ease-in-out infinite;
-  }
+/* Subtle dot-grid background */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 1px 1px, oklch(40% 0.02 270 / 0.18) 1px, transparent 0);
+  background-size: 24px 24px;
+  mask-image: radial-gradient(ellipse 70% 60% at 50% 30%, black 30%, transparent 80%);
+  pointer-events: none;
+  z-index: 0;
 }
 
-/* Scrollbar Styling */
-::-webkit-scrollbar {
-  width: 10px;
+/* Soft top glow */
+body::after {
+  content: "";
+  position: fixed;
+  top: -300px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1200px;
+  height: 600px;
+  background: radial-gradient(ellipse at center, var(--accent-soft) 0%, transparent 60%);
+  filter: blur(40px);
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.6;
 }
 
-::-webkit-scrollbar-track {
-  @apply bg-gray-100 dark:bg-gray-800;
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+::selection { background: var(--accent-soft); color: var(--accent-hi); }
+
+/* ============================================================
+   Layout primitives
+   ============================================================ */
+.app { position: relative; z-index: 1; }
+.container-x {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0 var(--pad-x);
+}
+.section {
+  padding: clamp(72px, 10vw, 120px) 0;
+  position: relative;
+}
+.section-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 48px;
+  flex-wrap: wrap;
+}
+.section-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  color: var(--fg-dim);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.section-eyebrow .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+.section-eyebrow .num { color: var(--fg-faint); }
+.section-title {
+  font-size: clamp(28px, 4vw, 44px);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0;
+  max-width: 720px;
+  text-wrap: balance;
+}
+.section-title em {
+  font-style: normal;
+  color: var(--fg-dim);
+}
+.section-sub {
+  color: var(--fg-mute);
+  max-width: 480px;
+  font-size: 15px;
+  margin: 0;
 }
 
-::-webkit-scrollbar-thumb {
-  @apply bg-gradient-to-b from-purple-500 to-pink-500 rounded-full;
+/* ============================================================
+   Buttons
+   ============================================================ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: var(--r-md);
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--fg);
+  transition: all 160ms ease;
+  font-family: var(--font-sans);
+  white-space: nowrap;
+  cursor: pointer;
+}
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-dim);
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid var(--border);
+  margin-left: 4px;
+}
+.btn-primary {
+  background: var(--accent);
+  color: oklch(15% 0.04 290);
+  font-weight: 600;
+}
+.btn-primary:hover {
+  background: var(--accent-hi);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 28px var(--accent-glow);
+}
+.btn-ghost {
+  background: var(--bg-card);
+  border-color: var(--border);
+  color: var(--fg);
+}
+.btn-ghost:hover {
+  background: var(--bg-card-hi);
+  border-color: var(--border-hi);
+}
+.btn-link {
+  color: var(--fg-mute);
+  padding: 10px 8px;
+}
+.btn-link:hover { color: var(--fg); }
+.btn svg { width: 16px; height: 16px; }
+
+/* ============================================================
+   Nav
+   ============================================================ */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  padding: 14px 0;
+  backdrop-filter: blur(12px);
+  background: oklch(14% 0.012 270 / 0.75);
+  border-bottom: 1px solid transparent;
+  transition: border-color 200ms ease;
+}
+.nav.scrolled { border-bottom-color: var(--border-soft); }
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--fg);
+  font-weight: 500;
+}
+.nav-brand .prompt { color: var(--accent); }
+.nav-brand .cursor {
+  display: inline-block;
+  width: 7px; height: 14px;
+  background: var(--accent);
+  vertical-align: -2px;
+  animation: blink 1s steps(1) infinite;
+  margin-left: 1px;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.nav-links {
+  display: flex;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+.nav-links a {
+  padding: 8px 12px;
+  border-radius: 6px;
+  color: var(--fg-mute);
+  transition: all 150ms ease;
+  cursor: pointer;
+}
+.nav-links a:hover { color: var(--fg); background: var(--bg-card); }
+
+.nav-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  min-width: 240px;
+  transition: all 150ms ease;
+  cursor: pointer;
+}
+.nav-search:hover { border-color: var(--border-hi); color: var(--fg-mute); }
+.nav-search .kbd {
+  font-size: 11px;
+  padding: 1px 5px;
+  background: var(--bg-elev);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  margin-left: auto;
+  color: var(--fg-dim);
 }
 
-::-webkit-scrollbar-thumb:hover {
-  @apply from-purple-600 to-pink-600;
+@media (max-width: 820px) {
+  .nav-links { display: none; }
+  .nav-search { min-width: 0; }
+  .nav-search .label { display: none; }
 }
 
-/* Selection Styling */
-::selection {
-  @apply bg-purple-500 text-white;
+/* ============================================================
+   Hero
+   ============================================================ */
+.hero {
+  padding: clamp(64px, 8vw, 96px) 0 clamp(72px, 9vw, 100px);
+  position: relative;
+}
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(40px, 6vw, 80px);
+  align-items: center;
+}
+@media (max-width: 940px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 48px; }
+}
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px 6px 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+  margin-bottom: 28px;
+}
+.hero-eyebrow .pulse {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 0 var(--green);
+  animation: pulse 2s infinite;
+}
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.5); }
+  70% { box-shadow: 0 0 0 8px rgba(74, 222, 128, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0); }
+}
+.hero h1 {
+  font-size: clamp(40px, 5.6vw, 68px);
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  line-height: 1.02;
+  margin: 0 0 24px;
+  text-wrap: balance;
+  color: var(--fg);
+}
+.hero h1 .accent {
+  color: var(--accent);
+  font-style: italic;
+  font-weight: 400;
+}
+.hero h1 .ul {
+  background-image: linear-gradient(transparent 88%, var(--accent-line) 88%);
+  background-size: 100% 100%;
+  padding: 0 2px;
+}
+.hero-sub {
+  font-size: 17px;
+  color: var(--fg-mute);
+  max-width: 520px;
+  margin: 0 0 36px;
+  line-height: 1.55;
+}
+.hero-sub strong { color: var(--fg); font-weight: 500; }
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 36px;
+}
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+.hero-meta-item { display: flex; align-items: center; gap: 8px; }
+.hero-meta-item .ico { color: var(--accent); }
+
+/* Terminal */
+.term {
+  background: linear-gradient(180deg, oklch(18% 0.016 270) 0%, oklch(16% 0.014 270) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow:
+    0 0 0 1px oklch(30% 0.02 270 / 0.3),
+    0 30px 60px -20px rgba(0,0,0,0.6),
+    0 0 80px -20px var(--accent-soft);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  overflow: hidden;
+  position: relative;
+}
+.term::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, var(--accent-soft) 0%, transparent 30%);
+  pointer-events: none;
+  opacity: 0.4;
+}
+.term-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  background: oklch(15% 0.012 270 / 0.5);
+}
+.term-dot {
+  width: 11px; height: 11px; border-radius: 50%;
+  background: var(--bg-card-hi);
+}
+.term-dot.r { background: #ff5f57; }
+.term-dot.y { background: #febc2e; }
+.term-dot.g { background: #28c840; }
+.term-title {
+  font-size: 11px;
+  color: var(--fg-faint);
+  margin-left: auto;
+  margin-right: auto;
+  padding-right: 33px;
+}
+.term-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 11px;
+}
+.term-tab {
+  padding: 8px 14px;
+  color: var(--fg-faint);
+  border-right: 1px solid var(--border-soft);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.term-tab.active { color: var(--fg-mute); background: oklch(20% 0.015 270 / 0.4); }
+.term-tab .close { opacity: 0.4; }
+.term-body {
+  padding: 18px 18px 22px;
+  min-height: 360px;
+  color: var(--fg-mute);
+  line-height: 1.7;
+}
+.term-body .prompt { color: var(--accent); user-select: none; }
+.term-body .cmd { color: var(--fg); }
+.term-body .flag { color: var(--blue); }
+.term-body .key { color: var(--fg-dim); }
+.term-body .val { color: var(--fg); }
+.term-body .val-accent { color: var(--accent-hi); }
+.term-body .val-green { color: var(--green); }
+.term-body .val-amber { color: var(--amber); }
+.term-body .comment { color: var(--fg-faint); }
+.term-body .ok { color: var(--green); }
+.term-body .arrow { color: var(--fg-faint); }
+.term-body .line { display: block; min-height: 1.7em; }
+.term-cursor {
+  display: inline-block;
+  width: 8px; height: 14px;
+  background: var(--accent);
+  vertical-align: -2px;
+  animation: blink 1s steps(1) infinite;
 }
 
-::-moz-selection {
-  @apply bg-purple-500 text-white;
+/* ============================================================
+   Card + general utilities
+   ============================================================ */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 24px;
+  transition: all 200ms ease;
 }
+.card:hover {
+  border-color: var(--border-hi);
+  background: var(--bg-card-hi);
+  transform: translateY(-2px);
+}
+.label-mono {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+/* Problems */
+.problems-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+@media (max-width: 820px) { .problems-grid { grid-template-columns: 1fr; } }
+
+.problem {
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+  position: relative;
+  overflow: hidden;
+  transition: all 220ms ease;
+}
+.problem::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0;
+  width: 3px; height: 100%;
+  background: var(--accent);
+  transform: scaleY(0);
+  transform-origin: top;
+  transition: transform 300ms ease;
+}
+.problem:hover { border-color: var(--border-hi); }
+.problem:hover::before { transform: scaleY(1); }
+.problem-issue {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+}
+.problem-issue .badge {
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hi);
+  background: var(--bg-elev);
+  color: var(--accent);
+  font-size: 10px;
+}
+.problem-q {
+  font-size: 19px;
+  font-weight: 500;
+  margin: 0 0 10px;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: var(--fg);
+}
+.problem-a {
+  color: var(--fg-mute);
+  font-size: 14.5px;
+  margin: 0 0 18px;
+  line-height: 1.55;
+}
+.problem-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.problem-tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--fg-mute);
+}
+
+/* Pipeline */
+.pipeline {
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+  overflow: hidden;
+}
+.pipeline-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border-soft);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+}
+.pipeline-bar .dot { width: 7px; height: 7px; border-radius: 50%; }
+.pipeline-bar .ok { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.pipeline-bar .path { color: var(--fg-faint); margin-left: 8px; }
+.pipeline-bar .ts { margin-left: auto; color: var(--fg-faint); }
+.pipeline-steps {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+}
+@media (max-width: 1100px) { .pipeline-steps { grid-template-columns: repeat(4, 1fr); } }
+@media (max-width: 640px) { .pipeline-steps { grid-template-columns: repeat(2, 1fr); } }
+
+.pipe-step {
+  position: relative;
+  padding: 22px 18px;
+  border-right: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  transition: background 200ms ease;
+}
+.pipe-step:hover { background: var(--bg-card-hi); }
+.pipe-step:last-child { border-right: none; }
+.pipe-step .idx {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.pipe-step .idx .ind {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--accent);
+}
+.pipe-step h4 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  font-family: var(--font-mono);
+  color: var(--fg);
+}
+.pipe-step p {
+  font-size: 12.5px;
+  color: var(--fg-mute);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.pipeline-log {
+  padding: 16px 20px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+  border-top: 1px solid var(--border-soft);
+  background: oklch(15% 0.012 270 / 0.6);
+}
+.pipeline-log .row { display: flex; gap: 12px; padding: 3px 0; }
+.pipeline-log .ts { color: var(--fg-faint); flex-shrink: 0; }
+.pipeline-log .tag { flex-shrink: 0; min-width: 70px; }
+.pipeline-log .tag.info { color: var(--blue); }
+.pipeline-log .tag.ok { color: var(--green); }
+.pipeline-log .tag.warn { color: var(--amber); }
+.pipeline-log .msg { color: var(--fg-mute); }
+
+/* Agentic */
+.agentic-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 32px;
+  align-items: stretch;
+}
+@media (max-width: 960px) { .agentic-grid { grid-template-columns: 1fr; } }
+
+.agent-flow {
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: linear-gradient(180deg, var(--bg-card) 0%, oklch(17% 0.014 270) 100%);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+}
+.agent-node {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--r-md);
+  background: var(--bg-elev);
+  transition: all 200ms ease;
+}
+.agent-node.is-human {
+  border-color: var(--amber);
+  background: linear-gradient(90deg, var(--amber-soft) 0%, transparent 100%);
+}
+.agent-node.is-output {
+  border-color: var(--green);
+  background: linear-gradient(90deg, var(--green-soft) 0%, transparent 100%);
+}
+.agent-icon {
+  width: 36px; height: 36px;
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  background: oklch(22% 0.018 270);
+  border: 1px solid var(--border);
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.agent-node.is-human .agent-icon { color: var(--amber); }
+.agent-node.is-output .agent-icon { color: var(--green); }
+.agent-icon svg { width: 18px; height: 18px; }
+.agent-name {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
+}
+.agent-role {
+  font-size: 12px;
+  color: var(--fg-mute);
+  margin-top: 2px;
+}
+.agent-status {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.agent-status.ok { color: var(--green); }
+.agent-status.human { color: var(--amber); }
+.agent-status .dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+.agent-arrow {
+  height: 12px;
+  width: 1px;
+  background: var(--border-hi);
+  margin-left: 35px;
+  position: relative;
+}
+.agent-arrow::after {
+  content: "";
+  position: absolute;
+  bottom: -2px; left: -3px;
+  width: 7px; height: 7px;
+  border-right: 1px solid var(--border-hi);
+  border-bottom: 1px solid var(--border-hi);
+  transform: rotate(45deg);
+}
+
+.agent-copy h3 {
+  font-size: 24px;
+  font-weight: 500;
+  margin: 0 0 16px;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+  color: var(--fg);
+}
+.agent-copy p {
+  color: var(--fg-mute);
+  font-size: 15px;
+  margin: 0 0 14px;
+  line-height: 1.6;
+}
+.agent-principles {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 24px;
+}
+.agent-principle {
+  display: flex;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--fg-mute);
+}
+.agent-principle .pn {
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-size: 12px;
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+.agent-principle strong { color: var(--fg); font-weight: 500; }
+
+/* Services */
+.services-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--border-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+@media (max-width: 1000px) { .services-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px) { .services-grid { grid-template-columns: 1fr; } }
+
+.service {
+  padding: 26px 24px;
+  background: var(--bg-card);
+  transition: all 200ms ease;
+  cursor: default;
+}
+.service:hover {
+  background: var(--bg-card-hi);
+}
+.service-ico {
+  width: 32px; height: 32px;
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  margin-bottom: 18px;
+}
+.service-ico svg { width: 22px; height: 22px; }
+.service h4 {
+  font-size: 15px;
+  font-weight: 500;
+  margin: 0 0 8px;
+  letter-spacing: -0.005em;
+  color: var(--fg);
+}
+.service p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--fg-mute);
+  line-height: 1.55;
+}
+
+/* Projects */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+@media (max-width: 880px) { .projects-grid { grid-template-columns: 1fr; } }
+
+.project {
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+  overflow: hidden;
+  position: relative;
+  transition: all 220ms ease;
+  display: flex;
+  flex-direction: column;
+}
+.project:hover {
+  border-color: var(--border-hi);
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px -20px rgba(0,0,0,0.4);
+}
+.project-head {
+  padding: 18px 22px 14px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  border-bottom: 1px solid var(--border-soft);
+  background: linear-gradient(180deg, var(--bg-card-hi) 0%, transparent 100%);
+}
+.project-folder {
+  width: 32px; height: 32px;
+  border-radius: 8px;
+  background: var(--accent-soft);
+  display: grid; place-items: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.project-folder svg { width: 16px; height: 16px; }
+.project-title-row {
+  flex: 1; min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.project-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--fg);
+  font-weight: 500;
+}
+.project-title .slash { color: var(--fg-faint); }
+.project-title .badge {
+  margin-left: auto;
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+.project-tagline {
+  font-size: 12.5px;
+  color: var(--fg-mute);
+  margin-top: 4px;
+}
+.project-body {
+  padding: 18px 22px 16px;
+  flex: 1;
+}
+.project-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 12px;
+  padding: 6px 0;
+  font-size: 13px;
+  align-items: baseline;
+}
+.project-row .k {
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.project-row .v { color: var(--fg-mute); line-height: 1.5; }
+.project-row .v strong { color: var(--fg); font-weight: 500; }
+
+.project-foot {
+  padding: 12px 22px 16px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border-top: 1px solid var(--border-soft);
+  background: oklch(15% 0.012 270 / 0.4);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg-dim);
+}
+.project-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1;
+}
+.project-stack span {
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--fg-mute);
+  font-size: 11px;
+}
+.project-links {
+  display: flex;
+  gap: 14px;
+  margin-left: auto;
+}
+.project-links a {
+  color: var(--fg-mute);
+  display: flex; align-items: center; gap: 4px;
+  transition: color 150ms ease;
+}
+.project-links a:hover { color: var(--accent); }
+.project-links svg { width: 13px; height: 13px; }
+
+/* Experience */
+.experience-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 48px;
+}
+@media (max-width: 900px) { .experience-grid { grid-template-columns: 1fr; gap: 32px; } }
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+.stat {
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-card);
+}
+.stat-num {
+  font-size: 32px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  color: var(--fg);
+  font-feature-settings: "ss01", "tnum";
+  line-height: 1;
+}
+.stat-num .small { font-size: 18px; color: var(--accent); margin-left: 2px; }
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-mute);
+  margin-top: 8px;
+  letter-spacing: 0.03em;
+}
+
+.mission-log {
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+  overflow: hidden;
+}
+.mission-row {
+  display: grid;
+  grid-template-columns: 110px 1fr auto;
+  gap: 20px;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--border-soft);
+  align-items: center;
+  position: relative;
+  font-size: 14px;
+}
+.mission-row:last-child { border-bottom: none; }
+.mission-row .when {
+  font-family: var(--font-mono);
+  color: var(--fg-faint);
+  font-size: 12px;
+}
+.mission-row .what strong { color: var(--fg); font-weight: 500; }
+.mission-row .what .where { color: var(--fg-mute); display: block; font-size: 12.5px; margin-top: 2px; }
+.mission-row .status {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.status-active { background: var(--green-soft); color: var(--green); }
+.status-done { background: var(--bg-elev); color: var(--fg-dim); border: 1px solid var(--border); }
+
+@media (max-width: 560px) {
+  .mission-row { grid-template-columns: 1fr; gap: 8px; }
+  .mission-row .status { justify-self: start; }
+}
+
+/* Skills */
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+@media (max-width: 900px) { .skills-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px) { .skills-grid { grid-template-columns: 1fr; } }
+
+.skill-card {
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+  padding: 22px;
+  transition: all 200ms ease;
+}
+.skill-card:hover { border-color: var(--border-hi); background: var(--bg-card-hi); }
+.skill-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+}
+.skill-head .ico {
+  width: 26px; height: 26px;
+  display: grid; place-items: center;
+  border-radius: 7px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.skill-head .ico svg { width: 14px; height: 14px; }
+.skill-head strong { color: var(--fg); font-weight: 500; font-size: 14px; font-family: var(--font-sans); }
+.skill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.skill-list span {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg-mute);
+}
+
+/* GitHub */
+.gh-card {
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+  overflow: hidden;
+}
+.gh-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border-soft);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+}
+.gh-bar .at { color: var(--accent); }
+.gh-bar .where { color: var(--fg-faint); margin-left: 4px; }
+.gh-bar .followers { margin-left: auto; display: flex; gap: 16px; color: var(--fg-faint); }
+.gh-bar .followers b { color: var(--fg); font-weight: 500; }
+.gh-body { padding: 24px; }
+
+.gh-graph {
+  display: grid;
+  grid-template-columns: repeat(53, 1fr);
+  gap: 3px;
+  margin-bottom: 8px;
+}
+.gh-cell {
+  aspect-ratio: 1;
+  border-radius: 2px;
+  background: oklch(22% 0.013 270);
+}
+.gh-cell.l1 { background: rgba(183, 148, 255, 0.25); }
+.gh-cell.l2 { background: rgba(183, 148, 255, 0.5); }
+.gh-cell.l3 { background: rgba(183, 148, 255, 0.75); }
+.gh-cell.l4 { background: var(--accent); }
+.gh-graph-meta {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  margin-top: 8px;
+}
+.gh-graph-meta .scale {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.gh-graph-meta .scale .gh-cell { width: 10px; height: 10px; aspect-ratio: auto; }
+
+.gh-repos {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-top: 28px;
+}
+@media (max-width: 720px) { .gh-repos { grid-template-columns: 1fr; } }
+.gh-repo {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 16px 18px;
+  background: var(--bg-elev);
+  transition: all 180ms ease;
+}
+.gh-repo:hover { border-color: var(--accent-line); }
+.gh-repo-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+.gh-repo-name .pub {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--fg-faint);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.gh-repo-desc {
+  font-size: 13px;
+  color: var(--fg-mute);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+.gh-repo-meta {
+  display: flex;
+  gap: 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-dim);
+  align-items: center;
+}
+.gh-repo-meta .lang-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--blue);
+  display: inline-block;
+  margin-right: 4px;
+  vertical-align: -1px;
+}
+.gh-repo-meta span { display: flex; align-items: center; gap: 4px; }
+.gh-repo-meta svg { width: 11px; height: 11px; }
+
+/* Writing */
+.writing-list { display: flex; flex-direction: column; }
+.writing-row {
+  display: grid;
+  grid-template-columns: 100px 1fr auto;
+  gap: 24px;
+  padding: 22px 0;
+  border-top: 1px solid var(--border-soft);
+  align-items: baseline;
+  transition: padding 200ms ease;
+}
+.writing-row:hover { padding-left: 8px; }
+.writing-row:last-child { border-bottom: 1px solid var(--border-soft); }
+.writing-row .date {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+.writing-row .title {
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+  color: var(--fg);
+}
+.writing-row .meta {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-mute);
+  display: flex; gap: 14px;
+}
+.writing-row .meta .tag { color: var(--accent); }
+.writing-row .arrow-btn {
+  width: 32px; height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: var(--fg-mute);
+  transition: all 200ms ease;
+}
+.writing-row:hover .arrow-btn {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: rotate(-45deg);
+}
+.writing-row .arrow-btn svg { width: 14px; height: 14px; }
+
+@media (max-width: 640px) {
+  .writing-row { grid-template-columns: 1fr; gap: 6px; }
+  .writing-row .arrow-btn { display: none; }
+}
+
+/* Contact */
+.contact {
+  padding: clamp(72px, 10vw, 120px) 0;
+  position: relative;
+}
+.contact-card {
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  background:
+    radial-gradient(ellipse at top, var(--accent-soft) 0%, transparent 50%),
+    var(--bg-card);
+  padding: clamp(40px, 6vw, 64px);
+  overflow: hidden;
+  position: relative;
+}
+.contact-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 1px 1px, oklch(50% 0.03 290 / 0.15) 1px, transparent 0);
+  background-size: 22px 22px;
+  pointer-events: none;
+  opacity: 0.4;
+  mask-image: radial-gradient(ellipse at top, black 0%, transparent 70%);
+}
+.contact-card > * { position: relative; }
+.contact-prompt {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent);
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.contact h2 {
+  font-size: clamp(32px, 5vw, 52px);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  margin: 0 0 20px;
+  max-width: 720px;
+  text-wrap: balance;
+  color: var(--fg);
+}
+.contact h2 em { color: var(--accent); font-style: normal; }
+.contact-sub {
+  color: var(--fg-mute);
+  font-size: 17px;
+  max-width: 580px;
+  margin: 0 0 36px;
+  line-height: 1.55;
+}
+.contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 40px;
+}
+.contact-channels {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--border-soft);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+}
+@media (max-width: 760px) { .contact-channels { grid-template-columns: repeat(2, 1fr); } }
+.channel {
+  padding: 18px;
+  background: oklch(15% 0.012 270 / 0.5);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transition: background 180ms ease;
+}
+.channel:hover { background: var(--bg-card-hi); }
+.channel-ico {
+  width: 36px; height: 36px;
+  border-radius: 9px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.channel-ico svg { width: 16px; height: 16px; }
+.channel-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-faint);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.channel-val {
+  font-size: 13px;
+  color: var(--fg);
+  font-weight: 500;
+}
+
+/* Footer */
+.foot {
+  padding: 40px 0 56px;
+  border-top: 1px solid var(--border-soft);
+  margin-top: 40px;
+}
+.foot-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-faint);
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.foot .live { display: flex; align-items: center; gap: 8px; }
+.foot .live .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 8px var(--green);
+}
+
+/* Command Palette */
+.cp-backdrop {
+  position: fixed;
+  inset: 0;
+  background: oklch(10% 0.01 270 / 0.7);
+  backdrop-filter: blur(8px);
+  z-index: 100;
+  display: grid;
+  place-items: flex-start center;
+  padding-top: 12vh;
+  animation: fade 180ms ease;
+}
+@keyframes fade { from { opacity: 0; } }
+.cp {
+  width: min(580px, 92vw);
+  background: var(--bg-card);
+  border: 1px solid var(--border-hi);
+  border-radius: var(--r-lg);
+  box-shadow: 0 30px 80px -20px rgba(0,0,0,0.6), 0 0 0 1px var(--border);
+  overflow: hidden;
+}
+.cp-input-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.cp-input-row svg { width: 16px; height: 16px; color: var(--fg-dim); }
+.cp-input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 14px;
+}
+.cp-input::placeholder { color: var(--fg-faint); }
+.cp-list {
+  max-height: 50vh;
+  overflow-y: auto;
+  padding: 8px;
+}
+.cp-section-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-faint);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 8px 12px 4px;
+}
+.cp-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--fg-mute);
+  font-size: 14px;
+  transition: all 100ms ease;
+}
+.cp-item.is-active { background: var(--bg-elev); color: var(--fg); }
+.cp-item .cp-ico {
+  width: 28px; height: 28px;
+  border-radius: 7px;
+  display: grid; place-items: center;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.cp-item.is-active .cp-ico { background: var(--accent-soft); }
+.cp-item .cp-ico svg { width: 14px; height: 14px; }
+.cp-item .cp-shortcut {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+}
+.cp-foot {
+  display: flex;
+  gap: 16px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+}
+.cp-foot kbd {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: inherit;
+  color: var(--fg-dim);
+  margin: 0 3px;
+}
+
+/* Reveal on scroll */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 700ms ease, transform 700ms cubic-bezier(.2,.7,.2,1);
+}
+.reveal.in {
+  opacity: 1;
+  transform: none;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--border-hi); border-radius: 5px; }
+::-webkit-scrollbar-thumb:hover { background: var(--accent-line); }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,8 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
-import { ThemeProvider } from "@/contexts/ThemeContext";
-
-const inter = Inter({ subsets: ["latin"] });
+import { CommandPalette } from "@/components/CommandPalette";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://meherullah.dev/";
 const siteName = "Md Meher Ullah - AI-Augmented Software Engineer";
@@ -98,13 +95,22 @@ export default function RootLayout({
 	children: React.ReactNode;
 }>) {
 	return (
-		<html lang="en" suppressHydrationWarning>
-			<body className={inter.className} suppressHydrationWarning>
-				<ThemeProvider>
+		<html lang="en">
+			<head>
+				<link rel="preconnect" href="https://fonts.googleapis.com" />
+				<link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+				<link
+					rel="stylesheet"
+					href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap"
+				/>
+			</head>
+			<body>
+				<div className="app">
 					<Header />
 					{children}
 					<Footer />
-				</ThemeProvider>
+				</div>
+				<CommandPalette />
 			</body>
 		</html>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,29 @@
 import { Hero } from '@/components/Hero'
-import { About } from '@/components/About'
-import { Skills } from '@/components/Skills'
+import { FounderProblems } from '@/components/FounderProblems'
+import { BuildProcess } from '@/components/BuildProcess'
+import { AgenticEngineering } from '@/components/AgenticEngineering'
+import { Services } from '@/components/Services'
 import { Projects } from '@/components/Projects'
+import { Experience } from '@/components/Experience'
+import { Skills } from '@/components/Skills'
+import { GitHubDashboard } from '@/components/GitHubDashboard'
 import { BlogPreview } from '@/components/BlogPreview'
 import { Contact } from '@/components/Contact'
 
 export default function Home() {
   return (
-    <>
+    <main id="top">
       <Hero />
-      <About />
-      <Skills />
+      <FounderProblems />
+      <BuildProcess />
+      <AgenticEngineering />
+      <Services />
       <Projects />
+      <Experience />
+      <Skills />
+      <GitHubDashboard />
       <BlogPreview />
       <Contact />
-    </>
+    </main>
   )
 }

--- a/src/components/AgenticEngineering.tsx
+++ b/src/components/AgenticEngineering.tsx
@@ -1,0 +1,140 @@
+export function AgenticEngineering() {
+  return (
+    <section className="section" id="agentic">
+      <div className="container-x">
+        <div className="section-head reveal">
+          <div>
+            <div className="section-eyebrow">
+              <span className="dot"></span>
+              <span className="num">03</span>
+              <span>agentic engineering</span>
+            </div>
+            <h2 className="section-title">
+              AI-assisted, <em>human-owned</em> engineering.
+            </h2>
+          </div>
+          <p className="section-sub">
+            Agents move drafts. Humans own decisions. The handoff between
+            them is where most teams get burned &mdash; that&apos;s the part I take
+            care of.
+          </p>
+        </div>
+
+        <div className="agentic-grid">
+          <div className="agent-flow reveal" aria-hidden="false">
+            <div className="agent-node is-human">
+              <div className="agent-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+              </div>
+              <div>
+                <div className="agent-name">founder.goal</div>
+                <div className="agent-role">What outcome are we shipping?</div>
+              </div>
+              <div className="agent-status human"><span className="dot"></span>input</div>
+            </div>
+            <span className="agent-arrow"></span>
+
+            <div className="agent-node">
+              <div className="agent-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5"/><path d="m21 12-9 5-9-5"/><path d="m12 2 9 5-9 5-9-5 9-5Z"/></svg>
+              </div>
+              <div>
+                <div className="agent-name">architect.agent</div>
+                <div className="agent-role">data model &middot; API contracts &middot; constraints</div>
+              </div>
+              <div className="agent-status ok"><span className="dot"></span>ready</div>
+            </div>
+            <span className="agent-arrow"></span>
+
+            <div className="agent-node">
+              <div className="agent-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+              </div>
+              <div>
+                <div className="agent-name">coder.agent</div>
+                <div className="agent-role">drafts typed full-stack implementation</div>
+              </div>
+              <div className="agent-status ok"><span className="dot"></span>running</div>
+            </div>
+            <span className="agent-arrow"></span>
+
+            <div className="agent-node">
+              <div className="agent-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m9 12 2 2 4-4"/></svg>
+              </div>
+              <div>
+                <div className="agent-name">reviewer.agent</div>
+                <div className="agent-role">static analysis &middot; security &middot; diffs</div>
+              </div>
+              <div className="agent-status ok"><span className="dot"></span>passed</div>
+            </div>
+            <span className="agent-arrow"></span>
+
+            <div className="agent-node">
+              <div className="agent-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+              </div>
+              <div>
+                <div className="agent-name">tester.agent</div>
+                <div className="agent-role">unit + integration on real DBs</div>
+              </div>
+              <div className="agent-status ok"><span className="dot"></span>green</div>
+            </div>
+            <span className="agent-arrow"></span>
+
+            <div className="agent-node is-human">
+              <div className="agent-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg>
+              </div>
+              <div>
+                <div className="agent-name">human.judgment</div>
+                <div className="agent-role">architecture &amp; trade-offs &middot; the part that matters</div>
+              </div>
+              <div className="agent-status human"><span className="dot"></span>me</div>
+            </div>
+            <span className="agent-arrow"></span>
+
+            <div className="agent-node is-output">
+              <div className="agent-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7"/><path d="M16 6l-4-4-4 4"/><path d="M12 2v14"/></svg>
+              </div>
+              <div>
+                <div className="agent-name">production.release</div>
+                <div className="agent-role">shipped &middot; monitored &middot; accountable</div>
+              </div>
+              <div className="agent-status ok"><span className="dot"></span>live</div>
+            </div>
+          </div>
+
+          <div className="agent-copy reveal">
+            <h3>I use AI as leverage. I don&apos;t outsource judgment to it.</h3>
+            <p>
+              Agents draft code fast. They also confidently produce subtle
+              bugs, security holes, and architectures that don&apos;t survive
+              contact with real users. I keep humans in the loop where it
+              counts.
+            </p>
+            <div className="agent-principles">
+              <div className="agent-principle">
+                <span className="pn">01</span>
+                <span><strong>Architecture is owned.</strong> Data models, service boundaries, and trade-offs are decided deliberately &mdash; not whatever the model felt like emitting.</span>
+              </div>
+              <div className="agent-principle">
+                <span className="pn">02</span>
+                <span><strong>Every diff is read.</strong> AI-generated code goes through the same review bar as anything I&apos;d write by hand.</span>
+              </div>
+              <div className="agent-principle">
+                <span className="pn">03</span>
+                <span><strong>Tests on real infrastructure.</strong> Mocked tests aren&apos;t proof &mdash; integration tests against real databases are.</span>
+              </div>
+              <div className="agent-principle">
+                <span className="pn">04</span>
+                <span><strong>Maintainability over cleverness.</strong> If the next engineer can&apos;t read it in a week, it doesn&apos;t ship.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/BlogPreview.tsx
+++ b/src/components/BlogPreview.tsx
@@ -1,124 +1,56 @@
-'use client'
-
 export function BlogPreview() {
-  const blogPosts = [
-    {
-      title: 'AWS CloudWatch Alarms for Node.js Background Jobs: A Practical Setup',
-      excerpt: 'A comprehensive guide to setting up CloudWatch alarms for monitoring Node.js background jobs, ensuring reliability and performance in production environments.',
-      date: 'Recent',
-      readTime: '8 min read',
-      url: 'https://rajkhaan.medium.com/aws-cloudwatch-alarms-for-node-js-background-jobs-a-practical-setup-94f59e06a7d7',
-      tags: ['AWS', 'Node.js', 'CloudWatch', 'DevOps']
-    },
-    {
-      title: 'Configuring Nginx, PHP, MySQL & phpMyAdmin on Ubuntu 20.04',
-      excerpt: 'A complete A-Z guide for configuring Nginx, PHP, MySQL, and phpMyAdmin on Ubuntu 20.04, including project deployment best practices.',
-      date: 'Recent',
-      readTime: '12 min read',
-      url: 'https://rajkhaan.medium.com/configuring-nginx-php-mysql-phpmyadmin-on-ubuntu-20-04-a-to-z-with-project-deployment-cf47bd3d1715',
-      tags: ['Nginx', 'PHP', 'MySQL', 'Ubuntu']
-    },
-    {
-      title: 'Nginx & Apache2 Configuration for CodeIgniter',
-      excerpt: 'Learn how to properly configure Nginx and Apache2 web servers for CodeIgniter applications with optimization and security best practices.',
-      date: 'Recent',
-      readTime: '6 min read',
-      url: 'https://rajkhaan.medium.com/nginx-apache2-configuration-for-codeigniter-444872ff6ab2',
-      tags: ['Nginx', 'Apache', 'CodeIgniter', 'PHP']
-    },
-    {
-      title: 'Export Google Contacts Using Node.js and People API',
-      excerpt: 'A step-by-step tutorial on exporting Google Contacts using Node.js and the Google People API, perfect for building contact management features.',
-      date: 'Recent',
-      readTime: '7 min read',
-      url: 'https://rajkhaan.medium.com/export-google-contacts-using-node-js-and-people-api-662039ab6730',
-      tags: ['Node.js', 'Google API', 'JavaScript']
-    }
-  ]
-
   return (
-    <section id="blog" className="py-20 bg-gradient-to-b from-white to-slate-50 dark:from-gray-800 dark:to-gray-900">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent mb-4">
-            Latest Blog Posts
-          </h2>
-          <div className="w-20 h-1 bg-gradient-to-r from-purple-600 to-pink-600 mx-auto rounded-full mb-6"></div>
-          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-            Thoughts on software development, architecture, and technology
+    <section className="section" id="writing">
+      <div className="container">
+        <div className="section-head reveal">
+          <div>
+            <div className="section-eyebrow">
+              <span className="dot"></span>
+              <span className="num">09</span>
+              <span>engineering notes</span>
+            </div>
+            <h2 className="section-title">
+              Notes from the field.
+            </h2>
+          </div>
+          <p className="section-sub">
+            Practical writing on architecture, AI workflows, and getting
+            things to production. No hype.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
-          {blogPosts.map((post, index) => (
-            <a
-              key={index}
-              href={post.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group block bg-white dark:bg-gray-800 rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 dark:border-gray-700 hover:border-purple-200 dark:hover:border-purple-800 hover:-translate-y-2 cursor-pointer"
-            >
-              {/* Gradient Header */}
-              <div className={`h-2 bg-gradient-to-r ${
-                index === 0 ? 'from-purple-500 to-pink-500' :
-                index === 1 ? 'from-blue-500 to-cyan-500' :
-                index === 2 ? 'from-green-500 to-teal-500' :
-                'from-orange-500 to-yellow-500'
-              }`}></div>
-
-              <div className="p-6">
-                {/* Tags */}
-                <div className="flex flex-wrap gap-2 mb-4">
-                  {post.tags.map((tag, tagIndex) => (
-                    <span
-                      key={tagIndex}
-                      className="px-3 py-1 bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 text-xs font-semibold rounded-lg"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-
-                {/* Title */}
-                <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-3 group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors line-clamp-2">
-                  {post.title}
-                </h3>
-
-                {/* Excerpt */}
-                <p className="text-gray-600 dark:text-gray-300 mb-4 line-clamp-3">
-                  {post.excerpt}
-                </p>
-
-                {/* Meta */}
-                <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400 mb-4">
-                  <span>{post.date}</span>
-                  <span>{post.readTime}</span>
-                </div>
-
-                {/* Read More Indicator */}
-                <div className="inline-flex items-center text-purple-600 dark:text-purple-400 font-semibold group-hover:text-purple-700 dark:group-hover:text-purple-300 transition-colors">
-                  Read on Medium
-                  <svg className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                  </svg>
-                </div>
-              </div>
-            </a>
-          ))}
-        </div>
-
-        {/* View All Button */}
-        <div className="text-center">
-          <a
-            href="https://rajkhaan.medium.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center px-8 py-4 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-xl font-semibold hover:shadow-2xl hover:shadow-purple-500/50 transition-all duration-300 hover:scale-105"
-          >
-            <svg className="w-6 h-6 mr-2" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/>
-            </svg>
-            View All Posts on Medium
+        <div className="writing-list reveal">
+          <a className="writing-row" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+            <span className="date">2026 · 04</span>
+            <span>
+              <h3 className="title">Agents as drafts, humans as decisions</h3>
+              <span className="meta"><span className="tag">#agentic</span><span>~6 min read</span></span>
+            </span>
+            <span className="arrow-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>
+          </a>
+          <a className="writing-row" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+            <span className="date">2026 · 02</span>
+            <span>
+              <h3 className="title">Scaling a sleepy NestJS app on AWS without rewriting it</h3>
+              <span className="meta"><span className="tag">#backend</span><span>~9 min read</span></span>
+            </span>
+            <span className="arrow-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>
+          </a>
+          <a className="writing-row" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+            <span className="date">2025 · 11</span>
+            <span>
+              <h3 className="title">Idea → spec → tickets: the cheapest leverage in product</h3>
+              <span className="meta"><span className="tag">#process</span><span>~7 min read</span></span>
+            </span>
+            <span className="arrow-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>
+          </a>
+          <a className="writing-row" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+            <span className="date">2025 · 08</span>
+            <span>
+              <h3 className="title">CLI workflows beat dashboards (until they don&apos;t)</h3>
+              <span className="meta"><span className="tag">#devtools</span><span>~5 min read</span></span>
+            </span>
+            <span className="arrow-btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></span>
           </a>
         </div>
       </div>

--- a/src/components/BuildProcess.tsx
+++ b/src/components/BuildProcess.tsx
@@ -1,0 +1,92 @@
+export function BuildProcess() {
+  return (
+    <section className="section" id="process">
+      <div className="container-x">
+        <div className="section-head reveal">
+          <div>
+            <div className="section-eyebrow">
+              <span className="dot"></span>
+              <span className="num">02</span>
+              <span>build pipeline</span>
+            </div>
+            <h2 className="section-title">
+              From idea to shipped product, <em>step by step.</em>
+            </h2>
+          </div>
+          <p className="section-sub">
+            A repeatable pipeline for founders who want clarity at every
+            stage &mdash; not just a black-box &ldquo;we&rsquo;ll get it done&rdquo;.
+          </p>
+        </div>
+
+        <div className="pipeline reveal">
+          <div className="pipeline-bar">
+            <span className="dot ok"></span>
+            <span><strong>pipeline</strong> &middot; idea &rarr; production</span>
+            <span className="path">build/founder-engagement.yml</span>
+            <span className="ts">runtime &middot; weeks, not months</span>
+          </div>
+
+          <div className="pipeline-steps">
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>01 &middot; idea</div>
+              <h4>clarify</h4>
+              <p>Sharpen the goal, users, and constraints.</p>
+              <span className="arrow"></span>
+            </div>
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>02 &middot; spec</div>
+              <h4>scope</h4>
+              <p>Developer-ready tasks &amp; milestones.</p>
+              <span className="arrow"></span>
+            </div>
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>03 &middot; arch</div>
+              <h4>design</h4>
+              <p>System, data, API boundaries.</p>
+              <span className="arrow"></span>
+            </div>
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>04 &middot; ui</div>
+              <h4>build</h4>
+              <p>Next.js / React product interfaces.</p>
+              <span className="arrow"></span>
+            </div>
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>05 &middot; api</div>
+              <h4>wire</h4>
+              <p>NestJS / Node services &amp; Postgres.</p>
+              <span className="arrow"></span>
+            </div>
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>06 &middot; test</div>
+              <h4>verify</h4>
+              <p>Unit + integration, real DBs.</p>
+              <span className="arrow"></span>
+            </div>
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>07 &middot; ship</div>
+              <h4>deploy</h4>
+              <p>AWS, Docker, CI/CD.</p>
+              <span className="arrow"></span>
+            </div>
+            <div className="pipe-step">
+              <div className="idx"><span className="ind"></span>08 &middot; loop</div>
+              <h4>monitor</h4>
+              <p>Logs, metrics, real user feedback.</p>
+            </div>
+          </div>
+
+          <div className="pipeline-log">
+            <div className="row"><span className="ts">00:00.12</span><span className="tag info">info</span><span className="msg">discovery call &middot; founder goal captured</span></div>
+            <div className="row"><span className="ts">00:01.43</span><span className="tag info">spec</span><span className="msg">requirements &rarr; tasks &middot; estimate locked</span></div>
+            <div className="row"><span className="ts">00:02.07</span><span className="tag ok">ok</span><span className="msg">architecture &middot; postgres schema + REST boundary signed off</span></div>
+            <div className="row"><span className="ts">00:04.51</span><span className="tag info">build</span><span className="msg">next.js shell + auth + dashboards landed</span></div>
+            <div className="row"><span className="ts">00:05.18</span><span className="tag warn">review</span><span className="msg">human-in-the-loop pass &middot; 3 AI suggestions rejected</span></div>
+            <div className="row"><span className="ts">00:06.02</span><span className="tag ok">deploy</span><span className="msg">aws &middot; zero-downtime cut &middot; monitoring green</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,359 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+type PaletteItem = {
+  href: string
+  label: string
+  shortcut: string
+  external?: boolean
+  icon: React.ReactNode
+}
+
+type PaletteSection = {
+  label: string
+  items: PaletteItem[]
+}
+
+const SECTIONS: PaletteSection[] = [
+  {
+    label: 'Navigate',
+    items: [
+      {
+        href: '#founder-problems',
+        label: 'Where I help founders',
+        shortcut: '↵',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="9" />
+            <path d="M9 12h6" />
+          </svg>
+        ),
+      },
+      {
+        href: '#process',
+        label: 'Build process',
+        shortcut: '↵',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <path d="M3 9h18" />
+          </svg>
+        ),
+      },
+      {
+        href: '#agentic',
+        label: 'Agentic engineering',
+        shortcut: '↵',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="m12 2 9 5-9 5-9-5 9-5Z" />
+            <path d="m21 12-9 5-9-5" />
+          </svg>
+        ),
+      },
+      {
+        href: '#projects',
+        label: 'Projects',
+        shortcut: '↵',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+          </svg>
+        ),
+      },
+      {
+        href: '#experience',
+        label: 'Experience (mission log)',
+        shortcut: '↵',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="9" />
+            <polyline points="12 7 12 12 15 14" />
+          </svg>
+        ),
+      },
+      {
+        href: '#skills',
+        label: 'Skills',
+        shortcut: '↵',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="m12 2 3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7Z" />
+          </svg>
+        ),
+      },
+      {
+        href: '#github',
+        label: 'Open-source',
+        shortcut: '↵',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+          </svg>
+        ),
+      },
+    ],
+  },
+  {
+    label: 'Actions',
+    items: [
+      {
+        href: 'mailto:meherullah97@gmail.com',
+        label: 'Email Meher',
+        shortcut: '⌘ E',
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="5" width="18" height="14" rx="2" />
+            <path d="m3 7 9 6 9-6" />
+          </svg>
+        ),
+      },
+      {
+        href: '/Meher Ullah - Full-Stack Software Engineer.pdf',
+        label: 'Download CV',
+        shortcut: '⌘ D',
+        external: true,
+        icon: (
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        ),
+      },
+      {
+        href: 'https://github.com/raj-khan',
+        label: 'Open GitHub profile',
+        shortcut: '⌘ G',
+        external: true,
+        icon: (
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+          </svg>
+        ),
+      },
+      {
+        href: 'https://www.linkedin.com/in/raajkhan/',
+        label: 'Open LinkedIn',
+        shortcut: '⌘ L',
+        external: true,
+        icon: (
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M4 4h4v16H4zM6 2a2 2 0 1 1 0 4 2 2 0 0 1 0-4Zm5 6h4v2.2c.6-1 2-2.4 4.2-2.4 4.5 0 5.3 3 5.3 6.8V20h-4v-6.2c0-1.5 0-3.4-2.1-3.4S16 12 16 13.8V20h-4Z" />
+          </svg>
+        ),
+      },
+    ],
+  },
+]
+
+const FLAT_ITEMS: PaletteItem[] = SECTIONS.flatMap((s) => s.items)
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const backdropRef = useRef<HTMLDivElement | null>(null)
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  const visibleIndices = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return FLAT_ITEMS.map((item, idx) => ({ item, idx }))
+      .filter(({ item }) => !needle || item.label.toLowerCase().includes(needle))
+      .map(({ idx }) => idx)
+  }, [query])
+
+  const activate = useCallback((item: PaletteItem) => {
+    setOpen(false)
+    if (item.href.startsWith('#')) {
+      const target = document.querySelector(item.href)
+      if (target) {
+        ;(target as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+    } else if (item.href.startsWith('mailto:')) {
+      window.location.assign(item.href)
+    } else {
+      window.open(item.href, '_blank')
+    }
+  }, [])
+
+  // Open events: window event + ⌘K / Ctrl+K
+  useEffect(() => {
+    const onOpen = () => {
+      setQuery('')
+      setActiveIndex(0)
+      setOpen(true)
+    }
+    window.addEventListener('open-command-palette', onOpen as EventListener)
+    return () => window.removeEventListener('open-command-palette', onOpen as EventListener)
+  }, [])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const isMeta = e.metaKey || e.ctrlKey
+      if (isMeta && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault()
+        setOpen((prev) => {
+          if (prev) return false
+          setQuery('')
+          setActiveIndex(0)
+          return true
+        })
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [])
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) {
+      const t = setTimeout(() => inputRef.current?.focus(), 0)
+      return () => clearTimeout(t)
+    }
+  }, [open])
+
+  // Keep active index within visible range
+  useEffect(() => {
+    if (!visibleIndices.includes(activeIndex)) {
+      setActiveIndex(visibleIndices[0] ?? 0)
+    }
+  }, [visibleIndices, activeIndex])
+
+  // Key handling while open: Escape, arrows, Enter
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setOpen(false)
+        return
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        if (!visibleIndices.length) return
+        const cur = visibleIndices.indexOf(activeIndex)
+        const safeCur = cur === -1 ? 0 : cur
+        const nextPos =
+          e.key === 'ArrowDown'
+            ? (safeCur + 1) % visibleIndices.length
+            : (safeCur - 1 + visibleIndices.length) % visibleIndices.length
+        const nextIdx = visibleIndices[nextPos]
+        setActiveIndex(nextIdx)
+        const el = listRef.current?.querySelector<HTMLDivElement>(
+          `[data-cp-index="${nextIdx}"]`,
+        )
+        el?.scrollIntoView({ block: 'nearest' })
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        const item = FLAT_ITEMS[activeIndex]
+        if (item && visibleIndices.includes(activeIndex)) activate(item)
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, activeIndex, visibleIndices, activate])
+
+  const onBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === backdropRef.current) setOpen(false)
+  }
+
+  if (!open) return null
+
+  let flatCursor = 0
+
+  return (
+    <div className="cp-backdrop" ref={backdropRef} onClick={onBackdropClick}>
+      <div className="cp" role="dialog" aria-modal="true" aria-label="Command palette">
+        <div className="cp-input-row">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <input
+            ref={inputRef}
+            className="cp-input"
+            type="text"
+            placeholder="Type to search · jump to section, project, or contact…"
+            aria-label="Search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <span
+            className="kbd"
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: '11px',
+              padding: '2px 6px',
+              border: '1px solid var(--border)',
+              borderRadius: '4px',
+              color: 'var(--fg-dim)',
+            }}
+          >
+            ESC
+          </span>
+        </div>
+        <div className="cp-list" ref={listRef}>
+          {SECTIONS.map((section) => {
+            const sectionIndices: number[] = []
+            const startCursor = flatCursor
+            section.items.forEach(() => {
+              sectionIndices.push(flatCursor)
+              flatCursor += 1
+            })
+            const anyVisible = sectionIndices.some((i) => visibleIndices.includes(i))
+            if (!anyVisible) return null
+            return (
+              <div key={section.label}>
+                <div className="cp-section-label">{section.label}</div>
+                {section.items.map((item, i) => {
+                  const idx = startCursor + i
+                  const hidden = !visibleIndices.includes(idx)
+                  if (hidden) return null
+                  const isActive = idx === activeIndex
+                  return (
+                    <div
+                      key={item.href}
+                      className={`cp-item${isActive ? ' is-active' : ''}`}
+                      data-cp-index={idx}
+                      onMouseEnter={() => setActiveIndex(idx)}
+                      onClick={() => activate(item)}
+                    >
+                      <div className="cp-ico">{item.icon}</div>
+                      <span>{item.label}</span>
+                      <span className="cp-shortcut">{item.shortcut}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            )
+          })}
+        </div>
+        <div className="cp-foot">
+          <span>
+            <kbd>↑</kbd>
+            <kbd>↓</kbd> navigate
+          </span>
+          <span>
+            <kbd>↵</kbd> select
+          </span>
+          <span>
+            <kbd>esc</kbd> close
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,101 +1,64 @@
 export function Contact() {
-  const socialLinks = [
-    {
-      name: 'Email',
-      icon: (
-        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-        </svg>
-      ),
-      href: 'mailto:meherullah97@gmail.com',
-      label: 'meherullah97@gmail.com',
-      color: 'from-purple-500 to-pink-500'
-    },
-    {
-      name: 'LinkedIn',
-      icon: (
-        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-        </svg>
-      ),
-      href: 'https://linkedin.com/in/raajkhan',
-      label: 'linkedin.com/in/raajkhan',
-      color: 'from-blue-500 to-cyan-500'
-    },
-    {
-      name: 'GitHub',
-      icon: (
-        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
-        </svg>
-      ),
-      href: 'https://github.com/raj-khan',
-      label: 'github.com/raj-khan',
-      color: 'from-gray-500 to-gray-700'
-    },
-    {
-      name: 'Medium',
-      icon: (
-        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/>
-        </svg>
-      ),
-      href: 'https://rajkhaan.medium.com',
-      label: 'rajkhaan.medium.com',
-      color: 'from-green-500 to-emerald-500'
-    }
-  ]
-
   return (
-    <section id="contact" className="py-20 bg-gradient-to-b from-slate-50 to-white dark:from-gray-900 dark:to-gray-800 relative overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute top-0 left-0 w-96 h-96 bg-purple-300 dark:bg-purple-900 rounded-full mix-blend-multiply dark:mix-blend-soft-light filter blur-3xl opacity-20 -translate-x-1/2 -translate-y-1/2"></div>
-      <div className="absolute bottom-0 right-0 w-96 h-96 bg-pink-300 dark:bg-pink-900 rounded-full mix-blend-multiply dark:mix-blend-soft-light filter blur-3xl opacity-20 translate-x-1/2 translate-y-1/2"></div>
-
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl relative z-10">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent mb-4">
-            Get In Touch
+    <section className="contact" id="contact">
+      <div className="container reveal">
+        <div className="contact-card">
+          <div className="contact-prompt">
+            <span className="prompt" style={{ color: 'var(--accent)' }}>$</span>
+            <span>founder build --with meher</span>
+          </div>
+          <h2>
+            Have an idea you want to turn <em>into software?</em>
           </h2>
-          <div className="w-20 h-1 bg-gradient-to-r from-purple-600 to-pink-600 mx-auto rounded-full mb-6"></div>
-          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-            I'm always open to discussing new opportunities, interesting projects, or just having a chat about technology
+          <p className="contact-sub">
+            If you&apos;re a founder, startup, or engineering team with a
+            product idea, technical challenge, or AI workflow problem —
+            I can help you clarify it, build it, and ship it.
           </p>
-        </div>
+          <div className="contact-actions">
+            <a className="btn btn-primary" href="mailto:meherullah97@gmail.com">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
+              Email me
+            </a>
+            <a className="btn btn-ghost" href="https://www.linkedin.com/in/raajkhan/" target="_blank" rel="noopener">
+              Connect on LinkedIn
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
+            </a>
+            <a className="btn btn-ghost" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+              View GitHub
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
+            </a>
+          </div>
 
-        <div className="max-w-4xl mx-auto">
-          {/* Contact Information */}
-          <div className="space-y-6">
-            <div className="bg-gradient-to-br from-purple-500 to-pink-500 rounded-2xl p-8 text-white shadow-2xl">
-              <h3 className="text-2xl font-bold mb-6">Let's Connect</h3>
-              <p className="text-purple-100 mb-8">
-                Feel free to reach out through any of these channels. I typically respond within 24 hours.
-              </p>
-
-              {/* Social Links */}
-              <div className="space-y-4">
-                {socialLinks.map((link) => (
-                  <a
-                    key={link.name}
-                    href={link.href}
-                    target={link.name !== 'Email' ? '_blank' : undefined}
-                    rel={link.name !== 'Email' ? 'noopener noreferrer' : undefined}
-                    className="group flex items-center p-4 bg-white/10 backdrop-blur-sm rounded-xl hover:bg-white/20 transition-all duration-300 hover:scale-105"
-                  >
-                    <div className="w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center mr-4 group-hover:scale-110 transition-transform">
-                      {link.icon}
-                    </div>
-                    <div>
-                      <div className="font-semibold">{link.name}</div>
-                      <div className="text-sm text-purple-100">{link.label}</div>
-                    </div>
-                    <svg className="w-5 h-5 ml-auto group-hover:translate-x-2 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                    </svg>
-                  </a>
-                ))}
+          <div className="contact-channels">
+            <a className="channel" href="mailto:meherullah97@gmail.com">
+              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg></div>
+              <div>
+                <div className="channel-label">Email</div>
+                <div className="channel-val">meherullah97@gmail.com</div>
               </div>
-            </div>
+            </a>
+            <a className="channel" href="https://www.linkedin.com/in/raajkhan/" target="_blank" rel="noopener">
+              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4 4h4v16H4zM6 2a2 2 0 1 1 0 4 2 2 0 0 1 0-4Zm5 6h4v2.2c.6-1 2-2.4 4.2-2.4 4.5 0 5.3 3 5.3 6.8V20h-4v-6.2c0-1.5 0-3.4-2.1-3.4S16 12 16 13.8V20h-4Z"/></svg></div>
+              <div>
+                <div className="channel-label">LinkedIn</div>
+                <div className="channel-val">linkedin.com/raajkhan</div>
+              </div>
+            </a>
+            <a className="channel" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg></div>
+              <div>
+                <div className="channel-label">GitHub</div>
+                <div className="channel-val">github.com/raj-khan</div>
+              </div>
+            </a>
+            <a className="channel" href="/Meher Ullah - Full-Stack Software Engineer.pdf" target="_blank" rel="noopener">
+              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></div>
+              <div>
+                <div className="channel-label">CV</div>
+                <div className="channel-val">Download (PDF)</div>
+              </div>
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,0 +1,97 @@
+export function Experience() {
+	return (
+		<section className="section" id="experience">
+			<div className="container-x">
+				<div className="section-head reveal">
+					<div>
+						<div className="section-eyebrow">
+							<span className="dot"></span>
+							<span className="num">06</span>
+							<span>mission log</span>
+						</div>
+						<h2 className="section-title">
+							Eight years of{" "}
+							<em>shipping software in production.</em>
+						</h2>
+					</div>
+					<p className="section-sub">
+						Enterprise systems, SaaS products, and internal tools — owned
+						end-to-end across frontend, backend, and infrastructure.
+					</p>
+				</div>
+
+				<div className="experience-grid">
+					<div className="stats-grid reveal">
+						<div className="stat">
+							<div className="stat-num">
+								8<span className="small">+</span>
+							</div>
+							<div className="stat-label">years shipping</div>
+						</div>
+						<div className="stat">
+							<div className="stat-num">
+								40<span className="small">%</span>
+							</div>
+							<div className="stat-label">
+								response-time gain · scaling work
+							</div>
+						</div>
+						<div className="stat">
+							<div className="stat-num">4</div>
+							<div className="stat-label">production stacks owned</div>
+						</div>
+						<div className="stat">
+							<div className="stat-num">0</div>
+							<div className="stat-label">
+								days of prod downtime · post-scaling
+							</div>
+						</div>
+					</div>
+
+					<div className="mission-log reveal">
+						<div className="mission-row">
+							<span className="when">2022 — now</span>
+							<span className="what">
+								<strong>Senior Software Engineer</strong>
+								<span className="where">
+									Snappymob · Kuala Lumpur, Malaysia
+								</span>
+							</span>
+							<span className="status status-active">Active</span>
+						</div>
+						<div className="mission-row">
+							<span className="when">2022</span>
+							<span className="what">
+								<strong>PHP Developer</strong>
+								<span className="where">
+									Wipro Bangladesh Limited · Dhaka
+								</span>
+							</span>
+							<span className="status status-done">Done</span>
+						</div>
+						<div className="mission-row">
+							<span className="when">2019 — 2022</span>
+							<span className="what">
+								<strong>Software Developer</strong>
+								<span className="where">
+									SCT-Bangla Limited · Dhaka
+								</span>
+							</span>
+							<span className="status status-done">Done</span>
+						</div>
+						<div className="mission-row">
+							<span className="when">2017 — 2019</span>
+							<span className="what">
+								<strong>Full-Stack Web Developer</strong>
+								<span className="where">
+									Bangladesh Software Development (BSD) · Dhaka
+								</span>
+							</span>
+							<span className="status status-done">Done</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,124 +1,21 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
 export function Footer() {
-  const currentYear = new Date().getFullYear()
+  const [year, setYear] = useState<number>(2026)
+
+  useEffect(() => {
+    setYear(new Date().getFullYear())
+  }, [])
 
   return (
-    <footer className="relative bg-gradient-to-br from-gray-900 via-purple-900 to-gray-900 text-white overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute top-0 left-0 w-96 h-96 bg-purple-500 rounded-full mix-blend-multiply filter blur-3xl opacity-20 -translate-x-1/2 -translate-y-1/2"></div>
-      <div className="absolute bottom-0 right-0 w-96 h-96 bg-pink-500 rounded-full mix-blend-multiply filter blur-3xl opacity-20 translate-x-1/2 translate-y-1/2"></div>
-
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl relative z-10 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-12 mb-12">
-          {/* Brand Section */}
-          <div>
-            <h3 className="text-2xl font-bold mb-4 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
-              {'<Meher />'}
-            </h3>
-            <p className="text-gray-300 mb-6 leading-relaxed">
-              Full-Stack Software Engineer passionate about creating efficient, scalable web solutions.
-              Based in Kuala Lumpur, Malaysia.
-            </p>
-            <div className="flex space-x-4">
-              <a
-                href="https://github.com/raj-khan"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group w-10 h-10 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg flex items-center justify-center hover:bg-white/20 transition-all duration-300 hover:scale-110"
-              >
-                <span className="sr-only">GitHub</span>
-                <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
-                </svg>
-              </a>
-              <a
-                href="https://linkedin.com/in/raajkhan"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group w-10 h-10 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg flex items-center justify-center hover:bg-white/20 transition-all duration-300 hover:scale-110"
-              >
-                <span className="sr-only">LinkedIn</span>
-                <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                </svg>
-              </a>
-              <a
-                href="mailto:meherullah97@gmail.com"
-                className="group w-10 h-10 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg flex items-center justify-center hover:bg-white/20 transition-all duration-300 hover:scale-110"
-              >
-                <span className="sr-only">Email</span>
-                <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                </svg>
-              </a>
-              <a
-                href="https://rajkhaan.medium.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group w-10 h-10 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg flex items-center justify-center hover:bg-white/20 transition-all duration-300 hover:scale-110"
-              >
-                <span className="sr-only">Medium</span>
-                <svg className="w-5 h-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/>
-                </svg>
-              </a>
-            </div>
-          </div>
-
-          {/* Quick Links */}
-          <div>
-            <h4 className="text-lg font-bold mb-6 text-purple-200">Quick Links</h4>
-            <ul className="space-y-3">
-              {['About', 'Skills', 'Projects', 'Blog', 'Contact'].map((link) => (
-                <li key={link}>
-                  <a
-                    href={`#${link.toLowerCase()}`}
-                    className="group inline-flex items-center text-gray-300 hover:text-white transition-colors"
-                  >
-                    <span className="w-0 h-0.5 bg-gradient-to-r from-purple-500 to-pink-500 group-hover:w-4 transition-all duration-300 mr-0 group-hover:mr-2"></span>
-                    {link}
-                  </a>
-                </li>
-              ))}
-              <li>
-                <a
-                  href="https://rajkhaan.medium.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group inline-flex items-center text-gray-300 hover:text-white transition-colors"
-                >
-                  <span className="w-0 h-0.5 bg-gradient-to-r from-purple-500 to-pink-500 group-hover:w-4 transition-all duration-300 mr-0 group-hover:mr-2"></span>
-                  Medium
-                </a>
-              </li>
-            </ul>
-          </div>
-
-          {/* Technologies */}
-          <div>
-            <h4 className="text-lg font-bold mb-6 text-purple-200">Tech Stack</h4>
-            <div className="flex flex-wrap gap-2">
-              {['AI Tools', 'TypeScript', 'Node.js', 'React', 'AWS', 'Docker'].map((tech) => (
-                <span
-                  key={tech}
-                  className="px-3 py-1 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg text-sm text-gray-300 hover:bg-white/20 transition-all duration-300 hover:scale-105"
-                >
-                  {tech}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        {/* Bottom Section */}
-        <div className="border-t border-white/10 pt-8">
-          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-            <p className="text-gray-400 text-sm">
-              &copy; {currentYear} Meher Ullah Khan Raj. All rights reserved.
-            </p>
-            <p className="text-gray-400 text-sm">
-              Built with <span className="text-pink-400">Next.js</span>, <span className="text-purple-400">TypeScript</span> & <span className="text-blue-400">Tailwind CSS</span>
-            </p>
-          </div>
+    <footer className="foot">
+      <div className="container foot-inner">
+        <div>© <span data-year>{year}</span> Md. Meher Ullah Khan Raj · Built with care &amp; AI as leverage.</div>
+        <div className="live">
+          <span className="dot" aria-hidden="true"></span>
+          <span>system status · operational</span>
         </div>
       </div>
     </footer>

--- a/src/components/FounderProblems.tsx
+++ b/src/components/FounderProblems.tsx
@@ -1,0 +1,99 @@
+export function FounderProblems() {
+  return (
+    <section className="section" id="founder-problems">
+      <div className="container-x">
+        <div className="section-head reveal">
+          <div>
+            <div className="section-eyebrow">
+              <span className="dot" aria-hidden="true"></span>
+              <span className="num">01</span>
+              <span>where I help most</span>
+            </div>
+            <h2 className="section-title">
+              Problems founders bring me <em>&mdash; and how I solve them.</em>
+            </h2>
+          </div>
+          <p className="section-sub">
+            You don&apos;t need another contractor who only writes code. You
+            need a technical partner who can think with you about
+            product, architecture, and delivery.
+          </p>
+        </div>
+
+        <div className="problems-grid reveal">
+          <article className="problem">
+            <div className="problem-issue">
+              <span className="badge">ISSUE #01</span>
+              <span>no technical roadmap</span>
+            </div>
+            <h3 className="problem-q">You have a clear idea, but no path to a working product.</h3>
+            <p className="problem-a">
+              I translate fuzzy product ideas into developer-ready
+              requirements, an architecture sketch, and an honest delivery
+              plan you can ship from.
+            </p>
+            <div className="problem-tags">
+              <span className="problem-tag">discovery</span>
+              <span className="problem-tag">spec</span>
+              <span className="problem-tag">roadmap</span>
+            </div>
+          </article>
+
+          <article className="problem">
+            <div className="problem-issue">
+              <span className="badge">ISSUE #02</span>
+              <span>messy MVP</span>
+            </div>
+            <h3 className="problem-q">Your MVP works, but it&apos;s slow, fragile, or hard to extend.</h3>
+            <p className="problem-a">
+              I stabilize and refactor full-stack apps &mdash; database, APIs,
+              frontend &mdash; so you can grow on top of them instead of around
+              them.
+            </p>
+            <div className="problem-tags">
+              <span className="problem-tag">refactor</span>
+              <span className="problem-tag">performance</span>
+              <span className="problem-tag">postgres</span>
+            </div>
+          </article>
+
+          <article className="problem">
+            <div className="problem-issue">
+              <span className="badge">ISSUE #03</span>
+              <span>fractured ownership</span>
+            </div>
+            <h3 className="problem-q">You need one person who can own the whole build.</h3>
+            <p className="problem-a">
+              Frontend, backend, cloud, CI/CD, product decisions &mdash; I run
+              the whole stack so you don&apos;t have to coordinate five
+              vendors to ship one feature.
+            </p>
+            <div className="problem-tags">
+              <span className="problem-tag">full-stack</span>
+              <span className="problem-tag">aws</span>
+              <span className="problem-tag">ci/cd</span>
+            </div>
+          </article>
+
+          <article className="problem">
+            <div className="problem-issue">
+              <span className="badge">ISSUE #04</span>
+              <span>AI without chaos</span>
+            </div>
+            <h3 className="problem-q">You want to use AI without shipping broken code.</h3>
+            <p className="problem-a">
+              I use agents and CLI workflows for speed, but with review,
+              testing, and engineering judgment in the loop. AI is
+              leverage &mdash; not a substitute for ownership.
+            </p>
+            <div className="problem-tags">
+              <span className="problem-tag">agents</span>
+              <span className="problem-tag">review</span>
+              <span className="problem-tag">testing</span>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/GitHubDashboard.tsx
+++ b/src/components/GitHubDashboard.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+export function GitHubDashboard() {
+  const graphRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const graph = graphRef.current
+    if (!graph) return
+    const total = 53 * 7
+    let frag = ''
+    for (let i = 0; i < total; i++) {
+      const seed = (i * 9301 + 49297) % 233280
+      const r = seed / 233280
+      const week = Math.floor(i / 7)
+      const recent = week > 36 ? 0.25 : 0
+      const v = r + recent
+      let cls = ''
+      if (v > 0.92) cls = 'l4'
+      else if (v > 0.78) cls = 'l3'
+      else if (v > 0.6) cls = 'l2'
+      else if (v > 0.4) cls = 'l1'
+      frag += `<div class="gh-cell ${cls}"></div>`
+    }
+    graph.innerHTML = frag
+  }, [])
+
+  return (
+    <section className="section" id="github">
+      <div className="container">
+        <div className="section-head reveal">
+          <div>
+            <div className="section-eyebrow">
+              <span className="dot"></span>
+              <span className="num">08</span>
+              <span>open-source</span>
+            </div>
+            <h2 className="section-title">
+              I build &amp; experiment <em>in public.</em>
+            </h2>
+          </div>
+          <p className="section-sub">
+            Especially around AI-assisted software engineering, CLI
+            tools, and developer workflows.
+          </p>
+        </div>
+
+        <div className="gh-card reveal">
+          <div className="gh-bar">
+            <span><span className="at">@</span>raj-khan</span>
+            <span className="where">github.com/raj-khan</span>
+            <span className="followers">
+              <span><b>Repos</b> · public</span>
+              <span><b>Focus</b> · agentic + full-stack</span>
+            </span>
+          </div>
+          <div className="gh-body">
+            <div className="gh-graph" data-gh-graph aria-hidden="true" ref={graphRef}></div>
+            <div className="gh-graph-meta">
+              <span>contribution graph · last year</span>
+              <span className="scale">
+                less
+                <span className="gh-cell"></span>
+                <span className="gh-cell l1"></span>
+                <span className="gh-cell l2"></span>
+                <span className="gh-cell l3"></span>
+                <span className="gh-cell l4"></span>
+                more
+              </span>
+            </div>
+
+            <div className="gh-repos">
+              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+                <div className="gh-repo-name">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  aiagentflow
+                  <span className="pub">Public</span>
+                </div>
+                <p className="gh-repo-desc">Local-first CLI workflow for orchestrating coding agents on real repos.</p>
+                <div className="gh-repo-meta">
+                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
+                  <span><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg> agentic</span>
+                  <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="9"/></svg> CLI</span>
+                </div>
+              </a>
+              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+                <div className="gh-repo-name">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  e2spec
+                  <span className="pub">Public</span>
+                </div>
+                <p className="gh-repo-desc">Idea → spec pipeline that produces developer-ready tickets and PRDs.</p>
+                <div className="gh-repo-meta">
+                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
+                  <span>founder-tool</span>
+                  <span>LLM</span>
+                </div>
+              </a>
+              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+                <div className="gh-repo-name">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  SEORanksLab
+                  <span className="pub">Public</span>
+                </div>
+                <p className="gh-repo-desc">GSC-based platform turning search data into SEO action workflows.</p>
+                <div className="gh-repo-meta">
+                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
+                  <span>Next.js</span>
+                  <span>NestJS</span>
+                </div>
+              </a>
+              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+                <div className="gh-repo-name">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  quick-memorial
+                  <span className="pub">Public</span>
+                </div>
+                <p className="gh-repo-desc">Tiny SaaS for QR-shareable memorial pages — small surface, high care.</p>
+                <div className="gh-repo-meta">
+                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
+                  <span>Next.js</span>
+                  <span>S3</span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,203 +1,74 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import Link from 'next/link'
-import { useTheme } from '@/contexts/ThemeContext'
+import { useEffect, useState } from 'react'
 
 export function Header() {
-  const [isOpen, setIsOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
-  const { theme, toggleTheme } = useTheme()
 
   useEffect(() => {
-    const handleScroll = () => {
-      setScrolled(window.scrollY > 50)
-    }
-    window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
+    const onScroll = () => setScrolled(window.scrollY > 8)
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
   }, [])
 
-  const navigation = [
-    { name: 'Home', href: '#hero' },
-    { name: 'About', href: '#about' },
-    { name: 'Skills', href: '#skills' },
-    { name: 'Projects', href: '#projects' },
-    { name: 'Blog', href: '#blog' },
-    { name: 'Contact', href: '#contact' },
-  ]
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const isMeta = e.metaKey || e.ctrlKey
+      if (isMeta && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault()
+        window.dispatchEvent(new CustomEvent('open-command-palette'))
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [])
+
+  const openPalette = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    window.dispatchEvent(new CustomEvent('open-command-palette'))
+  }
 
   return (
-    <header
-      className={`fixed top-0 z-50 w-full transition-all duration-300 ${
-        scrolled
-          ? 'bg-white/80 dark:bg-gray-900/80 backdrop-blur-md shadow-lg border-b border-gray-200 dark:border-gray-700'
-          : 'bg-transparent'
-      }`}
-    >
-      <nav className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl">
-        <div className="flex justify-between items-center py-4">
-          {/* Logo */}
-          <Link href="/" className="group relative">
-            <span className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
-              {'<Meher />'}
-            </span>
-            <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-purple-600 to-pink-600 group-hover:w-full transition-all duration-300"></span>
-          </Link>
-
-          {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-1">
-            {navigation.map((item) => (
-              <Link
-                key={item.name}
-                href={item.href}
-                className={`relative px-4 py-2 text-sm font-medium transition-all duration-300 group ${
-                  scrolled
-                    ? 'text-gray-700 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400'
-                    : 'text-white hover:text-purple-300'
-                }`}
-              >
-                {item.name}
-                <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-0 h-0.5 bg-gradient-to-r from-purple-600 to-pink-600 group-hover:w-full transition-all duration-300"></span>
-              </Link>
-            ))}
-          </div>
-
-          {/* Theme Toggle & CTA - Desktop */}
-          <div className="hidden md:flex items-center space-x-3">
-            {/* Theme Toggle Button */}
-            <button
-              onClick={toggleTheme}
-              className={`group relative p-2.5 rounded-xl transition-all duration-300 hover:scale-110 ${
-                scrolled
-                  ? 'bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700'
-                  : 'bg-white/10 backdrop-blur-sm hover:bg-white/20'
-              }`}
-              aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-            >
-              {/* Sun Icon (visible in dark mode) */}
-              <svg
-                className={`w-5 h-5 transition-all duration-500 ${
-                  theme === 'dark'
-                    ? 'rotate-0 scale-100 opacity-100'
-                    : 'rotate-90 scale-0 opacity-0 absolute inset-0 m-auto'
-                } ${scrolled ? 'text-yellow-500' : 'text-yellow-300'}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-                />
-              </svg>
-
-              {/* Moon Icon (visible in light mode) */}
-              <svg
-                className={`w-5 h-5 transition-all duration-500 ${
-                  theme === 'light'
-                    ? 'rotate-0 scale-100 opacity-100'
-                    : '-rotate-90 scale-0 opacity-0 absolute inset-0 m-auto'
-                } ${scrolled ? 'text-purple-600' : 'text-purple-300'}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-                />
-              </svg>
-
-              {/* Hover effect ring */}
-              <span className="absolute inset-0 rounded-xl bg-gradient-to-r from-purple-500 to-pink-500 opacity-0 group-hover:opacity-20 transition-opacity duration-300"></span>
-            </button>
-
-            <Link
-              href="#contact"
-              className="px-6 py-2.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-xl font-semibold hover:shadow-lg hover:shadow-purple-500/50 transition-all duration-300 hover:scale-105"
-            >
-              Let's Talk
-            </Link>
-          </div>
-
-          {/* Mobile menu button */}
-          <button
-            type="button"
-            className={`md:hidden inline-flex items-center justify-center p-2 rounded-xl transition-all duration-300 ${
-              scrolled
-                ? 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
-                : 'text-white hover:bg-white/10'
-            }`}
-            onClick={() => setIsOpen(!isOpen)}
+    <header className={`nav${scrolled ? ' scrolled' : ''}`} role="banner">
+      <div className="container-x nav-inner">
+        <a className="nav-brand" href="#top" aria-label="Home">
+          <span className="prompt">~/</span>
+          <span>meher</span>
+          <span className="cursor" aria-hidden="true"></span>
+        </a>
+        <nav className="nav-links" aria-label="Primary">
+          <a href="#process">process</a>
+          <a href="#projects">projects</a>
+          <a href="#experience">experience</a>
+          <a href="#skills">skills</a>
+          <a href="#github">open-source</a>
+          <a href="#contact">contact</a>
+        </nav>
+        <button
+          type="button"
+          className="nav-search"
+          aria-label="Open command palette"
+          onClick={openPalette}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            width="14"
+            height="14"
+            aria-hidden="true"
           >
-            <span className="sr-only">Open main menu</span>
-            {!isOpen ? (
-              <svg className="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-            ) : (
-              <svg className="block h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            )}
-          </button>
-        </div>
-
-        {/* Mobile Navigation */}
-        {isOpen && (
-          <div className="md:hidden pb-4">
-            <div className="space-y-1 bg-white/95 dark:bg-gray-900/95 backdrop-blur-lg rounded-2xl p-4 shadow-xl border border-gray-200 dark:border-gray-700">
-              {navigation.map((item) => (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className="block px-4 py-3 text-base font-medium text-gray-700 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded-xl transition-all duration-300"
-                  onClick={() => setIsOpen(false)}
-                >
-                  {item.name}
-                </Link>
-              ))}
-
-              {/* Theme Toggle - Mobile */}
-              <button
-                onClick={toggleTheme}
-                className="w-full flex items-center justify-between px-4 py-3 text-base font-medium text-gray-700 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded-xl transition-all duration-300"
-              >
-                <span>{theme === 'light' ? 'Dark Mode' : 'Light Mode'}</span>
-                <div className="relative w-12 h-6 bg-gray-300 dark:bg-gray-600 rounded-full transition-colors duration-300">
-                  <div
-                    className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow-md transform transition-all duration-300 flex items-center justify-center ${
-                      theme === 'dark' ? 'translate-x-6' : 'translate-x-0'
-                    }`}
-                  >
-                    {theme === 'dark' ? (
-                      <svg className="w-3 h-3 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-                      </svg>
-                    ) : (
-                      <svg className="w-3 h-3 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-                      </svg>
-                    )}
-                  </div>
-                </div>
-              </button>
-
-              <Link
-                href="#contact"
-                className="block px-4 py-3 text-center bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-xl font-semibold hover:shadow-lg transition-all duration-300"
-                onClick={() => setIsOpen(false)}
-              >
-                Let's Talk
-              </Link>
-            </div>
-          </div>
-        )}
-      </nav>
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <span className="label">Search portfolio…</span>
+          <span className="kbd">⌘K</span>
+        </button>
+      </div>
     </header>
   )
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,123 +1,262 @@
 'use client'
 
-import Link from 'next/link'
+import { useEffect, useRef } from 'react'
+
+type TerminalLine = { delay: number; html: string }
+
+const TERMINAL_LINES: TerminalLine[] = [
+  { delay: 200, html: '<span class="line"><span class="prompt">$</span> <span class="cmd">npx meherullah --profile</span></span>' },
+  { delay: 400, html: '<span class="line comment"># Resolving developer identity…</span>' },
+  { delay: 350, html: '<span class="line"><span class="key">role</span><span class="arrow">:</span> <span class="val-accent">AI-Augmented Full-Stack Engineer</span></span>' },
+  { delay: 250, html: '<span class="line"><span class="key">experience</span><span class="arrow">:</span> <span class="val">8+ years</span></span>' },
+  { delay: 250, html: '<span class="line"><span class="key">focus</span><span class="arrow">:</span> <span class="val">TypeScript, Node.js, React, AWS, Agentic AI</span></span>' },
+  { delay: 250, html: '<span class="line"><span class="key">location</span><span class="arrow">:</span> <span class="val">Kuala Lumpur, Malaysia</span></span>' },
+  { delay: 250, html: '<span class="line"><span class="key">status</span><span class="arrow">:</span> <span class="val-green">building production systems + AI workflows</span></span>' },
+  { delay: 400, html: '<span class="line"></span>' },
+  { delay: 300, html: '<span class="line"><span class="prompt">$</span> <span class="cmd">founder build --with meher</span></span>' },
+  { delay: 350, html: '<span class="line"><span class="key">idea</span><span class="arrow">→</span> <span class="val">rough product concept</span></span>' },
+  { delay: 250, html: '<span class="line"><span class="key">spec</span><span class="arrow">→</span> <span class="val">developer-ready tasks</span></span>' },
+  { delay: 250, html: '<span class="line"><span class="key">stack</span><span class="arrow">→</span> <span class="val">Next.js · NestJS · PostgreSQL · AWS</span></span>' },
+  { delay: 250, html: '<span class="line"><span class="key">workflow</span><span class="arrow">→</span> <span class="val">architect → build → review → test → ship</span></span>' },
+  { delay: 300, html: '<span class="line"><span class="ok">✓ production-ready</span></span>' },
+]
 
 export function Hero() {
-  const scrollToProjects = () => {
-    const projectsSection = document.querySelector('#projects')
-    if (projectsSection) {
-      projectsSection.scrollIntoView({ behavior: 'smooth' })
+  const termBodyRef = useRef<HTMLDivElement | null>(null)
+  const rootRef = useRef<HTMLElement | null>(null)
+
+  // Reveal observer
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    const els = root.querySelectorAll<HTMLDivElement>('.reveal')
+    if (!('IntersectionObserver' in window) || !els.length) {
+      els.forEach((el) => el.classList.add('in'))
+      return
     }
-  }
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            e.target.classList.add('in')
+            io.unobserve(e.target)
+          }
+        })
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -40px 0px' },
+    )
+    els.forEach((el) => io.observe(el))
+    return () => io.disconnect()
+  }, [])
+
+  // Terminal animation
+  useEffect(() => {
+    const body = termBodyRef.current
+    if (!body) return
+    body.innerHTML = ''
+    let cancelled = false
+    let i = 0
+    const timeouts: ReturnType<typeof setTimeout>[] = []
+    const tick = () => {
+      if (cancelled) return
+      if (i >= TERMINAL_LINES.length) {
+        body.insertAdjacentHTML(
+          'beforeend',
+          '<span class="line"><span class="prompt">$</span> <span class="term-cursor"></span></span>',
+        )
+        return
+      }
+      const ln = TERMINAL_LINES[i++]
+      const t = setTimeout(() => {
+        if (cancelled || !termBodyRef.current) return
+        body.insertAdjacentHTML('beforeend', ln.html)
+        body.scrollTop = body.scrollHeight
+        tick()
+      }, ln.delay)
+      timeouts.push(t)
+    }
+    tick()
+    return () => {
+      cancelled = true
+      timeouts.forEach(clearTimeout)
+    }
+  }, [])
 
   return (
-    <section id="hero" className="relative min-h-screen pt-20 pb-32 flex items-center">
-      {/* Animated Background */}
-      <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 overflow-hidden">
-        <div className="absolute top-0 -left-4 w-72 h-72 bg-purple-500 rounded-full mix-blend-multiply filter blur-xl opacity-70 animate-blob"></div>
-        <div className="absolute top-0 -right-4 w-72 h-72 bg-yellow-500 rounded-full mix-blend-multiply filter blur-xl opacity-70 animate-blob animation-delay-2000"></div>
-        <div className="absolute -bottom-8 left-20 w-72 h-72 bg-pink-500 rounded-full mix-blend-multiply filter blur-xl opacity-70 animate-blob animation-delay-4000"></div>
-      </div>
-
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl relative z-10">
-        <div className="text-center">
-          {/* Badge */}
-          <div className="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full mb-8">
-            <span className="relative flex h-2 w-2 mr-3">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-purple-400 opacity-75"></span>
-              <span className="relative inline-flex rounded-full h-2 w-2 bg-purple-500"></span>
-            </span>
-            <span className="text-sm text-white/90">I'm always curious to learn</span>
+    <section className="hero" ref={rootRef}>
+      <div className="container-x hero-grid">
+        <div className="reveal">
+          <div className="hero-eyebrow">
+            <span className="pulse" aria-hidden="true"></span>
+            <span>Available for founder &amp; team engagements</span>
           </div>
-
-          {/* Main Heading */}
-          <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold mb-6 text-white">
-            Hi, I'm{' '}
-            <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-yellow-400 bg-clip-text text-transparent animate-gradient">
-              Meher Ullah
-            </span>
+          <h1>
+            I help founders turn <span className="ul">ideas</span> into{' '}
+            <span className="accent">production-ready</span> software.
           </h1>
-
-          <h2 className="text-2xl md:text-4xl font-semibold text-purple-200 mb-8">
-            AI-Augmented Software Engineer
-          </h2>
-
-          <p className="text-lg md:text-xl text-gray-300 mb-10 max-w-3xl mx-auto leading-relaxed">
-            Full-stack engineer with <span className="text-purple-400 font-semibold">8+ years</span> building scalable web applications, now specializing in{' '}
-            <span className="text-purple-400 font-semibold">AI-augmented development</span>. Expert in creating production-level code, improving AI-generated solutions, and fixing major issues.
-            Based in <span className="text-purple-400 font-semibold">Kuala Lumpur, Malaysia</span>.
+          <p className="hero-sub">
+            <strong>Meher Ullah Khan Raj</strong> — 8+ years building full-stack web systems.
+            From rough idea to architecture, implementation, and launch — with AI-assisted
+            workflows that actually ship.
           </p>
-
-          {/* CTA Buttons */}
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16">
-            <Link
-              href="#projects"
-              className="group relative inline-flex items-center px-8 py-4 text-lg font-semibold text-white bg-gradient-to-r from-purple-500 to-pink-500 rounded-xl overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-2xl hover:shadow-purple-500/50"
-            >
-              <span className="relative z-10">View My Work</span>
-              <svg className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+          <div className="hero-cta">
+            <a className="btn btn-primary" href="#contact">
+              Work with me
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
               </svg>
-            </Link>
-
-            <Link
-              href="#contact"
-              className="group inline-flex items-center px-8 py-4 text-lg font-semibold text-white bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl hover:bg-white/20 transition-all duration-300 hover:scale-105"
-            >
-              Get In Touch
-              <svg className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-              </svg>
-            </Link>
-
+            </a>
+            <a className="btn btn-ghost" href="#projects">
+              View projects
+            </a>
             <a
+              className="btn btn-ghost"
               href="/Meher Ullah - Full-Stack Software Engineer.pdf"
               target="_blank"
-              rel="noopener noreferrer"
-              className="group inline-flex items-center px-8 py-4 text-lg font-semibold text-white bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl hover:bg-white/20 transition-all duration-300 hover:scale-105"
+              rel="noopener"
             >
-              <svg className="w-5 h-5 mr-2 group-hover:-translate-y-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
               </svg>
               Download CV
             </a>
+            <a
+              className="btn btn-link"
+              href="https://github.com/raj-khan"
+              target="_blank"
+              rel="noopener"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+              </svg>
+              GitHub
+            </a>
           </div>
+          <div className="hero-meta">
+            <div className="hero-meta-item">
+              <span className="ico" aria-hidden="true">
+                <svg
+                  viewBox="0 0 24 24"
+                  width="14"
+                  height="14"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+              </span>
+              Kuala Lumpur, Malaysia
+            </div>
+            <div className="hero-meta-item">
+              <span className="ico" aria-hidden="true">
+                <svg
+                  viewBox="0 0 24 24"
+                  width="14"
+                  height="14"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+                </svg>
+              </span>
+              8+ years shipping production systems
+            </div>
+            <div className="hero-meta-item">
+              <span className="ico" aria-hidden="true">
+                <svg
+                  viewBox="0 0 24 24"
+                  width="14"
+                  height="14"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="3" y="4" width="18" height="14" rx="2" />
+                  <path d="m7 9 3 3-3 3" />
+                  <path d="M13 15h4" />
+                </svg>
+              </span>
+              Full-stack · AWS · Agentic AI
+            </div>
+          </div>
+        </div>
 
-          {/* Tech Stack */}
-          <div className="flex flex-wrap justify-center items-center gap-4">
-            {[
-              { name: 'AI Tools', icon: '🤖' },
-              { name: 'TypeScript', icon: '📘' },
-              { name: 'Node.js', icon: '🟢' },
-              { name: 'React', icon: '⚛️' },
-              { name: 'AWS', icon: '☁️' },
-              { name: 'Docker', icon: '🐳' }
-            ].map((tech) => (
-              <div
-                key={tech.name}
-                className="group relative px-6 py-3 bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl hover:bg-white/20 transition-all duration-300 hover:scale-110 hover:shadow-lg"
-              >
-                <span className="text-2xl mr-2">{tech.icon}</span>
-                <span className="text-sm font-medium text-white">{tech.name}</span>
+        <div className="reveal">
+          <div className="term" role="img" aria-label="Terminal showing Meher's profile output">
+            <div className="term-bar" aria-hidden="true">
+              <span className="term-dot r"></span>
+              <span className="term-dot y"></span>
+              <span className="term-dot g"></span>
+              <span className="term-title">~/meherullah — zsh</span>
+            </div>
+            <div className="term-tabs" aria-hidden="true">
+              <div className="term-tab active">
+                <svg
+                  viewBox="0 0 24 24"
+                  width="11"
+                  height="11"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="4 17 10 11 4 5" />
+                  <line x1="12" y1="19" x2="20" y2="19" />
+                </svg>
+                profile
+                <span className="close">×</span>
               </div>
-            ))}
+              <div className="term-tab">
+                <svg
+                  viewBox="0 0 24 24"
+                  width="11"
+                  height="11"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="4 17 10 11 4 5" />
+                  <line x1="12" y1="19" x2="20" y2="19" />
+                </svg>
+                build
+                <span className="close">×</span>
+              </div>
+            </div>
+            <div className="term-body" ref={termBodyRef}></div>
           </div>
         </div>
       </div>
-
-      {/* Scroll Indicator */}
-      <button
-        onClick={scrollToProjects}
-        className="absolute bottom-8 left-1/2 transform -translate-x-1/2 cursor-pointer group transition-all duration-300 hover:scale-110"
-        aria-label="Scroll to projects section"
-      >
-        <div className="flex flex-col items-center">
-          <span className="text-white/60 text-sm mb-2 group-hover:text-white/80 transition-colors">Scroll to explore</span>
-          <div className="w-6 h-10 border-2 border-white/30 rounded-full flex justify-center group-hover:border-white/50 transition-colors">
-            <div className="w-1 h-3 bg-white/60 rounded-full mt-2 animate-bounce group-hover:bg-white/80"></div>
-          </div>
-        </div>
-      </button>
     </section>
   )
 }

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,206 +1,314 @@
 export function Projects() {
-	const projects = [
-		{
-			title: "Personality Test Web App",
-			description:
-				"Interactive personality assessment tool featuring 16 MBTI-style personality types across 4 role categories. Built with modern Next.js, includes anonymous testing, beautiful result photocards, and social sharing capabilities.",
-			technologies: [
-				"Next.js",
-				"TypeScript",
-				"Tailwind CSS",
-				"Zustand",
-				"Turbo",
-			],
-			icon: "🧠",
-			githubUrl:
-				"https://github.com/raj-khan/raj-khan.github.io/tree/main/project/personality-app-web",
-			liveUrl: "/project/personality-web-app",
-		},
-		{
-			title: "Financial Application",
-			description:
-				"Enterprise-grade financial management system with real-time transaction processing, multi-currency support, automated reporting, and compliance features. Built with scalable architecture to handle high-volume transactions.",
-			technologies: ["TypeScript", "NestJS", "PostgreSQL", "AWS ECS", "Redis"],
-			icon: "💰",
-			githubUrl: "https://github.com/raj-khan",
-			liveUrl: null,
-		},
-		{
-			title: "HRM Application",
-			description:
-				"Comprehensive Human Resource Management system featuring employee onboarding, payroll processing, attendance tracking, performance reviews, and leave management. Streamlines HR workflows for organizations.",
-			technologies: ["Node.js", "React", "PostgreSQL", "Docker", "GraphQL"],
-			icon: "👥",
-			githubUrl: "https://github.com/raj-khan",
-			liveUrl: null,
-		},
-		{
-			title: "In-House Social Media App",
-			description:
-				"Custom enterprise social networking platform for internal team collaboration. Features include real-time messaging, content sharing, activity feeds, and team engagement analytics.",
-			technologies: ["Next.js", "NestJS", "WebSocket", "MongoDB", "AWS S3"],
-			icon: "🌐",
-			githubUrl: "https://github.com/raj-khan",
-			liveUrl: null,
-		},
-		{
-			title: "Custom Software Solutions",
-			description:
-				"Expert in building tailored software solutions from scratch. Specialized in AI-augmented development workflows, rapid prototyping, and delivering production-ready code that solves complex business challenges.",
-			technologies: ["TypeScript", "AI Tools", "Microservices", "AWS", "CI/CD"],
-			icon: "🛠️",
-			githubUrl: "https://github.com/raj-khan",
-			liveUrl: null,
-		},
-	];
-
 	return (
-		<section
-			id="projects"
-			className="py-20 bg-gradient-to-b from-white to-slate-50 dark:from-gray-800 dark:to-gray-900"
-		>
-			<div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl">
-				<div className="text-center mb-16">
-					<h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent mb-4">
-						Featured Projects
-					</h2>
-					<div className="w-20 h-1 bg-gradient-to-r from-purple-600 to-pink-600 mx-auto rounded-full mb-6"></div>
-					<p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-						Expert custom software maker specializing in Financial, HRM, and
-						Social Media applications
+		<section className="section" id="projects">
+			<div className="container-x">
+				<div className="section-head reveal">
+					<div>
+						<div className="section-eyebrow">
+							<span className="dot"></span>
+							<span className="num">05</span>
+							<span>build artifacts</span>
+						</div>
+						<h2 className="section-title">
+							Selected work &amp; <em>open-source builds.</em>
+						</h2>
+					</div>
+					<p className="section-sub">
+						A mix of public projects and production systems I&apos;ve owned —
+						each one is proof, not portfolio filler.
 					</p>
 				</div>
 
-				<div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-					{projects.map((project, index) => (
-						<div
-							key={index}
-							className="group relative bg-white dark:bg-gray-800 rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 dark:border-gray-700 hover:border-purple-200 dark:hover:border-purple-800 hover:-translate-y-2"
-						>
-							{/* Gradient Header */}
-							<div
-								className={`relative h-48 bg-gradient-to-br ${
-									index === 0
-										? "from-purple-500 to-pink-500"
-										: index === 1
-										? "from-blue-500 to-cyan-500"
-										: index === 2
-										? "from-green-500 to-teal-500"
-										: "from-orange-500 to-yellow-500"
-								} flex items-center justify-center overflow-hidden`}
-							>
-								{/* Decorative elements */}
-								<div className="absolute inset-0 bg-black/10"></div>
-								<div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full -mr-16 -mt-16"></div>
-								<div className="absolute bottom-0 left-0 w-24 h-24 bg-white/10 rounded-full -ml-12 -mb-12"></div>
-
-								{/* Icon */}
-								<div className="relative z-10 text-8xl group-hover:scale-110 transition-transform duration-300">
-									{project.icon}
-								</div>
-
-								{/* Gradient overlay on hover */}
-								<div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
+				<div className="projects-grid reveal">
+					<article className="project">
+						<header className="project-head">
+							<div className="project-folder">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+								</svg>
 							</div>
-
-							{/* Content */}
-							<div className="p-6">
-								<h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-3 group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors">
-									{project.title}
-								</h3>
-
-								<p className="text-gray-600 dark:text-gray-300 mb-6 leading-relaxed">
-									{project.description}
-								</p>
-
-								{/* Technologies */}
-								<div className="flex flex-wrap gap-2 mb-6">
-									{project.technologies.map((tech, techIndex) => (
-										<span
-											key={techIndex}
-											className="px-3 py-1.5 bg-gradient-to-r from-purple-50 to-pink-50 dark:from-purple-900/30 dark:to-pink-900/30 text-purple-700 dark:text-purple-300 text-xs font-semibold rounded-lg border border-purple-200 dark:border-purple-800 hover:scale-105 transition-transform"
-										>
-											{tech}
-										</span>
-									))}
+							<div className="project-title-row">
+								<div className="project-title">
+									<span className="slash">raj-khan /</span>
+									<span>aiagentflow</span>
+									<span className="badge">FEATURED</span>
 								</div>
-
-								{/* Action Buttons */}
-								<div className="flex gap-3">
-									{project.liveUrl && (
-										<a
-											href={project.liveUrl}
-											target={
-												project.liveUrl.startsWith("http") ? "_blank" : "_self"
-											}
-											rel={
-												project.liveUrl.startsWith("http")
-													? "noopener noreferrer"
-													: undefined
-											}
-											className="flex-1 inline-flex items-center justify-center px-4 py-2.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg font-semibold hover:shadow-lg hover:shadow-purple-500/50 transition-all duration-300 hover:scale-105"
-										>
-											<svg
-												className="w-4 h-4 mr-2"
-												fill="none"
-												stroke="currentColor"
-												viewBox="0 0 24 24"
-											>
-												<path
-													strokeLinecap="round"
-													strokeLinejoin="round"
-													strokeWidth={2}
-													d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-												/>
-											</svg>
-											View Live
-										</a>
-									)}
-									{project.githubUrl && (
-										<a
-											href={project.githubUrl}
-											target="_blank"
-											rel="noopener noreferrer"
-											className={`${
-												project.liveUrl ? "flex-1" : "w-full"
-											} inline-flex items-center justify-center px-4 py-2.5 bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white rounded-lg font-semibold hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-300 hover:scale-105`}
-										>
-											<svg
-												className="w-4 h-4 mr-2"
-												fill="currentColor"
-												viewBox="0 0 24 24"
-											>
-												<path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
-											</svg>
-											GitHub
-										</a>
-									)}
+								<div className="project-tagline">
+									Local-first CLI workflow for agentic software engineering.
 								</div>
 							</div>
-
-							{/* Decorative corner */}
-							<div className="absolute top-4 right-4 w-12 h-12 border-t-2 border-r-2 border-white/30 rounded-tr-2xl opacity-0 group-hover:opacity-100 transition-opacity"></div>
+						</header>
+						<div className="project-body">
+							<div className="project-row">
+								<span className="k">Problem</span>
+								<span className="v">
+									Most agentic tooling is cloud-locked, opaque, and hard to
+									wire into a real engineering workflow.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Built</span>
+								<span className="v">
+									<strong>A local-first orchestrator</strong> that runs
+									multiple coding agents against a real repo, with review
+									&amp; checkpointing in the loop.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Why</span>
+								<span className="v">
+									Engineers should own their agents — not the other way
+									around.
+								</span>
+							</div>
 						</div>
-					))}
-				</div>
+						<footer className="project-foot">
+							<div className="project-stack">
+								<span>TypeScript</span>
+								<span>Node.js</span>
+								<span>CLI</span>
+								<span>LLM</span>
+							</div>
+							<div className="project-links">
+								<a
+									href="https://github.com/raj-khan"
+									target="_blank"
+									rel="noopener"
+									aria-label="View on GitHub"
+								>
+									<svg viewBox="0 0 24 24" fill="currentColor">
+										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+									</svg>
+									<span>GitHub</span>
+								</a>
+							</div>
+						</footer>
+					</article>
 
-				{/* View More */}
-				<div className="mt-12 text-center">
-					<a
-						href="https://github.com/raj-khan"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="inline-flex items-center px-8 py-4 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-xl font-semibold hover:shadow-2xl hover:shadow-purple-500/50 transition-all duration-300 hover:scale-105"
-					>
-						<svg
-							className="w-6 h-6 mr-2"
-							fill="currentColor"
-							viewBox="0 0 24 24"
-						>
-							<path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
-						</svg>
-						View More on GitHub
-					</a>
+					<article className="project">
+						<header className="project-head">
+							<div className="project-folder">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+									<polyline points="14 2 14 8 20 8" />
+								</svg>
+							</div>
+							<div className="project-title-row">
+								<div className="project-title">
+									<span className="slash">raj-khan /</span>
+									<span>e2spec</span>
+									<span className="badge">FOUNDER TOOL</span>
+								</div>
+								<div className="project-tagline">
+									Turns rough ideas into developer-ready specifications.
+								</div>
+							</div>
+						</header>
+						<div className="project-body">
+							<div className="project-row">
+								<span className="k">Problem</span>
+								<span className="v">
+									Founders pitch ideas; engineers need tickets. The gap
+									costs weeks.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Built</span>
+								<span className="v">
+									<strong>A guided pipeline</strong> that converts vague
+									product ideas into structured PRDs, user stories, and
+									task breakdowns.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Why</span>
+								<span className="v">
+									Clear specs are the cheapest leverage in software
+									delivery.
+								</span>
+							</div>
+						</div>
+						<footer className="project-foot">
+							<div className="project-stack">
+								<span>Next.js</span>
+								<span>TypeScript</span>
+								<span>LLM</span>
+								<span>Postgres</span>
+							</div>
+							<div className="project-links">
+								<a
+									href="https://github.com/raj-khan"
+									target="_blank"
+									rel="noopener"
+								>
+									<svg viewBox="0 0 24 24" fill="currentColor">
+										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+									</svg>
+									<span>GitHub</span>
+								</a>
+							</div>
+						</footer>
+					</article>
+
+					<article className="project">
+						<header className="project-head">
+							<div className="project-folder">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<path d="M3 3h18v18H3z" />
+									<path d="M3 9h18" />
+									<path d="M9 21V9" />
+								</svg>
+							</div>
+							<div className="project-title-row">
+								<div className="project-title">
+									<span className="slash">raj-khan /</span>
+									<span>SEORanksLab</span>
+									<span className="badge">PRODUCT</span>
+								</div>
+								<div className="project-tagline">
+									GSC data → SEO action workflows.
+								</div>
+							</div>
+						</header>
+						<div className="project-body">
+							<div className="project-row">
+								<span className="k">Problem</span>
+								<span className="v">
+									Search Console gives data; teams need decisions and
+									actions.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Built</span>
+								<span className="v">
+									<strong>An SEO action platform</strong> that ingests GSC,
+									prioritizes opportunities, and tracks the work to ship
+									them.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Why</span>
+								<span className="v">
+									Insights without workflows are wallpaper.
+								</span>
+							</div>
+						</div>
+						<footer className="project-foot">
+							<div className="project-stack">
+								<span>Next.js</span>
+								<span>NestJS</span>
+								<span>Postgres</span>
+								<span>AWS</span>
+							</div>
+							<div className="project-links">
+								<a
+									href="https://github.com/raj-khan"
+									target="_blank"
+									rel="noopener"
+								>
+									<svg viewBox="0 0 24 24" fill="currentColor">
+										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+									</svg>
+									<span>GitHub</span>
+								</a>
+							</div>
+						</footer>
+					</article>
+
+					<article className="project">
+						<header className="project-head">
+							<div className="project-folder">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<rect x="3" y="3" width="18" height="18" rx="2" />
+									<path d="M3 9h18" />
+									<path d="m9 14 2 2 4-4" />
+								</svg>
+							</div>
+							<div className="project-title-row">
+								<div className="project-title">
+									<span className="slash">raj-khan /</span>
+									<span>quick-memorial</span>
+									<span className="badge">SHIPPED</span>
+								</div>
+								<div className="project-tagline">
+									Memorial page generator with QR sharing.
+								</div>
+							</div>
+						</header>
+						<div className="project-body">
+							<div className="project-row">
+								<span className="k">Problem</span>
+								<span className="v">
+									Families need a respectful, low-friction way to remember
+									loved ones together.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Built</span>
+								<span className="v">
+									<strong>A small SaaS</strong> that creates shareable
+									memorial pages with QR codes and quiet, accessible
+									design.
+								</span>
+							</div>
+							<div className="project-row">
+								<span className="k">Why</span>
+								<span className="v">Soft tech for hard moments.</span>
+							</div>
+						</div>
+						<footer className="project-foot">
+							<div className="project-stack">
+								<span>Next.js</span>
+								<span>TypeScript</span>
+								<span>S3</span>
+								<span>QR</span>
+							</div>
+							<div className="project-links">
+								<a
+									href="https://github.com/raj-khan"
+									target="_blank"
+									rel="noopener"
+								>
+									<svg viewBox="0 0 24 24" fill="currentColor">
+										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
+									</svg>
+									<span>GitHub</span>
+								</a>
+							</div>
+						</footer>
+					</article>
 				</div>
 			</div>
 		</section>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,0 +1,200 @@
+export function Services() {
+	return (
+		<section className="section" id="services">
+			<div className="container-x">
+				<div className="section-head reveal">
+					<div>
+						<div className="section-eyebrow">
+							<span className="dot"></span>
+							<span className="num">04</span>
+							<span>how I can help</span>
+						</div>
+						<h2 className="section-title">
+							Engagements I&apos;m built for.
+						</h2>
+					</div>
+					<p className="section-sub">
+						Fractional engineering for founders &amp; teams who need a
+						senior pair of hands across the whole stack.
+					</p>
+				</div>
+
+				<div className="services-grid reveal">
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<path d="m12 2 3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7Z" />
+							</svg>
+						</div>
+						<h4>MVP development</h4>
+						<p>
+							From rough idea to a usable v1 — built so it can grow, not
+							just shipped to a demo.
+						</p>
+					</div>
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<rect x="3" y="3" width="18" height="18" rx="2" />
+								<path d="M9 9h6v6H9z" />
+							</svg>
+						</div>
+						<h4>SaaS product build</h4>
+						<p>
+							Auth, billing, dashboards, multi-tenancy — the boring pieces
+							every SaaS actually needs.
+						</p>
+					</div>
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<path d="M4 4h16v4H4z" />
+								<path d="M4 12h10v4H4z" />
+								<path d="M4 20h16" />
+							</svg>
+						</div>
+						<h4>Full-stack delivery</h4>
+						<p>
+							Frontend, backend, infra — one accountable owner instead of
+							five vendors.
+						</p>
+					</div>
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<ellipse cx="12" cy="5" rx="9" ry="3" />
+								<path d="M3 5v6c0 1.66 4 3 9 3s9-1.34 9-3V5" />
+								<path d="M3 11v6c0 1.66 4 3 9 3s9-1.34 9-3v-6" />
+							</svg>
+						</div>
+						<h4>Backend &amp; API architecture</h4>
+						<p>
+							NestJS, Node, Postgres — services that hold up as the
+							product gets real.
+						</p>
+					</div>
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<circle cx="12" cy="12" r="3" />
+								<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" />
+							</svg>
+						</div>
+						<h4>AI workflow integration</h4>
+						<p>
+							Drop agents into real workflows — with review, tests, and
+							guardrails.
+						</p>
+					</div>
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<rect x="2" y="4" width="20" height="16" rx="2" />
+								<polyline points="6 10 9 13 6 16" />
+								<line x1="13" y1="16" x2="17" y2="16" />
+							</svg>
+						</div>
+						<h4>Developer tooling / CLIs</h4>
+						<p>
+							Local-first tools that make your team faster every single
+							day.
+						</p>
+					</div>
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+								<polyline points="14 2 14 8 20 8" />
+								<line x1="9" y1="13" x2="15" y2="13" />
+								<line x1="9" y1="17" x2="15" y2="17" />
+							</svg>
+						</div>
+						<h4>Technical planning</h4>
+						<p>
+							Turn rough ideas into specs, estimates, and a path your team
+							can actually run.
+						</p>
+					</div>
+					<div className="service">
+						<div className="service-ico">
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<path d="M9 12h6" />
+								<path d="M12 9v6" />
+								<circle cx="12" cy="12" r="9" />
+							</svg>
+						</div>
+						<h4>Production debugging</h4>
+						<p>
+							Performance regressions, outages, mystery bugs — diagnosed
+							and put to bed.
+						</p>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,162 +1,190 @@
 export function Skills() {
-  const skillCategories = [
-    {
-      title: 'AI & Development',
-      icon: '🤖',
-      skills: [
-        { name: 'Cursor AI', level: 95 },
-        { name: 'GitHub Copilot', level: 90 },
-        { name: 'Claude', level: 90 },
-        { name: 'Prompt Engineering', level: 85 },
-      ]
-    },
-    {
-      title: 'Languages',
-      icon: '💻',
-      skills: [
-        { name: 'JavaScript', level: 95 },
-        { name: 'TypeScript', level: 90 },
-        { name: 'SQL', level: 85 },
-        { name: 'HTML/CSS', level: 90 },
-      ]
-    },
-    {
-      title: 'Frameworks',
-      icon: '⚡',
-      skills: [
-        { name: 'Node.js', level: 95 },
-        { name: 'React', level: 90 },
-        { name: 'Next.js', level: 85 },
-        { name: 'NestJS', level: 80 },
-      ]
-    },
-    {
-      title: 'Databases',
-      icon: '🗄️',
-      skills: [
-        { name: 'PostgreSQL', level: 90 },
-        { name: 'MongoDB', level: 75 },
-        { name: 'Redis', level: 80 },
-        { name: 'MySQL', level: 75 },
-      ]
-    },
-    {
-      title: 'DevOps & Cloud',
-      icon: '☁️',
-      skills: [
-        { name: 'AWS (ECS/RDS/S3)', level: 85 },
-        { name: 'Docker', level: 85 },
-        { name: 'Kubernetes', level: 75 },
-        { name: 'CI/CD (GitHub)', level: 90 },
-      ]
-    },
-    {
-      title: 'Monitoring',
-      icon: '📊',
-      skills: [
-        { name: 'New Relic', level: 80 },
-        { name: 'DataDog', level: 75 },
-        { name: 'CloudWatch', level: 85 },
-        { name: 'ELK Stack', level: 70 },
-      ]
-    }
-  ]
+	return (
+		<section className="section" id="skills">
+			<div className="container-x">
+				<div className="section-head reveal">
+					<div>
+						<div className="section-eyebrow">
+							<span className="dot"></span>
+							<span className="num">07</span>
+							<span>capabilities</span>
+						</div>
+						<h2 className="section-title">
+							Tools I reach for, <em>grouped by what they do.</em>
+						</h2>
+					</div>
+					<p className="section-sub">
+						No fake percentage bars — just the actual stack I use to ship
+						production software.
+					</p>
+				</div>
 
-  return (
-    <section id="skills" className="py-20 bg-white dark:bg-gray-800 relative overflow-hidden">
-      {/* Background decoration */}
-      <div className="absolute inset-0 bg-gradient-to-br from-purple-50 to-pink-50 dark:from-gray-900 dark:to-gray-800 opacity-50"></div>
-      <div className="absolute top-20 right-20 w-64 h-64 bg-purple-300 dark:bg-purple-900 rounded-full mix-blend-multiply dark:mix-blend-soft-light filter blur-3xl opacity-20 animate-blob"></div>
-      <div className="absolute bottom-20 left-20 w-64 h-64 bg-pink-300 dark:bg-pink-900 rounded-full mix-blend-multiply dark:mix-blend-soft-light filter blur-3xl opacity-20 animate-blob animation-delay-2000"></div>
-
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl relative z-10">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent mb-4">
-            Technical Skills
-          </h2>
-          <div className="w-20 h-1 bg-gradient-to-r from-purple-600 to-pink-600 mx-auto rounded-full mb-6"></div>
-          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-            Technologies and tools I use to craft exceptional digital experiences
-          </p>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6">
-          {skillCategories.map((category, categoryIndex) => (
-            <div
-              key={categoryIndex}
-              className="group relative bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 dark:border-gray-700 hover:border-purple-200 dark:hover:border-purple-800 hover:-translate-y-2"
-            >
-              {/* Category Header */}
-              <div className="flex items-center justify-center mb-6">
-                <div className="w-16 h-16 bg-gradient-to-br from-purple-500 to-pink-500 rounded-2xl flex items-center justify-center text-3xl shadow-lg group-hover:scale-110 transition-transform">
-                  {category.icon}
-                </div>
-              </div>
-
-              <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-6 text-center">
-                {category.title}
-              </h3>
-
-              {/* Skills */}
-              <div className="space-y-5">
-                {category.skills.map((skill, skillIndex) => (
-                  <div key={skillIndex} className="group/skill">
-                    <div className="flex justify-between items-center mb-2">
-                      <span className="text-sm font-semibold text-gray-700 dark:text-gray-300 group-hover/skill:text-purple-600 dark:group-hover/skill:text-purple-400 transition-colors">
-                        {skill.name}
-                      </span>
-                      <span className="text-xs font-bold text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-900/30 px-2 py-1 rounded-full">
-                        {skill.level}%
-                      </span>
-                    </div>
-                    <div className="relative w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
-                      <div
-                        className="absolute top-0 left-0 h-full bg-gradient-to-r from-purple-500 to-pink-500 rounded-full transition-all duration-1000 ease-out group-hover/skill:scale-x-105"
-                        style={{ width: `${skill.level}%` }}
-                      >
-                        <div className="absolute inset-0 bg-white/30 animate-shimmer"></div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* Decorative element */}
-              <div className="absolute -bottom-2 -right-2 w-20 h-20 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full opacity-0 group-hover:opacity-10 blur-2xl transition-opacity"></div>
-            </div>
-          ))}
-        </div>
-
-        {/* Additional Skills Pills */}
-        <div className="mt-16">
-          <h3 className="text-2xl font-bold text-center text-gray-900 dark:text-white mb-8">
-            Other Technologies
-          </h3>
-          <div className="flex flex-wrap justify-center gap-3">
-            {[
-              'AI Code Review',
-              'Prompt Engineering',
-              'RESTful APIs',
-              'GraphQL',
-              'WebSocket',
-              'Microservices',
-              'Swagger/OpenAPI',
-              'SonarCloud',
-              'TDD',
-              'Agile/Scrum',
-              'System Design',
-              'Performance Optimization'
-            ].map((tech, index) => (
-              <div
-                key={index}
-                className="group px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-full font-medium shadow-md hover:shadow-xl hover:scale-110 transition-all duration-300 cursor-default"
-              >
-                <span className="relative z-10">{tech}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  )
+				<div className="skills-grid reveal">
+					<div className="skill-card">
+						<div className="skill-head">
+							<span className="ico">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<rect x="3" y="3" width="18" height="18" rx="2" />
+									<path d="M3 9h18" />
+								</svg>
+							</span>
+							<strong>Product Engineering</strong>
+						</div>
+						<div className="skill-list">
+							<span>MVPs</span>
+							<span>SaaS</span>
+							<span>Dashboards</span>
+							<span>Internal tools</span>
+							<span>Multi-tenant</span>
+						</div>
+					</div>
+					<div className="skill-card">
+						<div className="skill-head">
+							<span className="ico">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<polyline points="4 17 10 11 4 5" />
+									<line x1="12" y1="19" x2="20" y2="19" />
+								</svg>
+							</span>
+							<strong>Frontend</strong>
+						</div>
+						<div className="skill-list">
+							<span>React</span>
+							<span>Next.js</span>
+							<span>TypeScript</span>
+							<span>Tailwind</span>
+							<span>Vite</span>
+						</div>
+					</div>
+					<div className="skill-card">
+						<div className="skill-head">
+							<span className="ico">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<ellipse cx="12" cy="5" rx="9" ry="3" />
+									<path d="M3 5v6c0 1.66 4 3 9 3s9-1.34 9-3V5" />
+									<path d="M3 11v6c0 1.66 4 3 9 3s9-1.34 9-3v-6" />
+								</svg>
+							</span>
+							<strong>Backend</strong>
+						</div>
+						<div className="skill-list">
+							<span>Node.js</span>
+							<span>NestJS</span>
+							<span>REST</span>
+							<span>GraphQL</span>
+							<span>PostgreSQL</span>
+							<span>MySQL</span>
+						</div>
+					</div>
+					<div className="skill-card">
+						<div className="skill-head">
+							<span className="ico">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<path d="M20 16.58A5 5 0 0 0 18 7h-1.26A8 8 0 1 0 4 15.25" />
+									<polyline points="8 19 12 23 16 19" />
+									<line x1="12" y1="13" x2="12" y2="23" />
+								</svg>
+							</span>
+							<strong>Cloud &amp; DevOps</strong>
+						</div>
+						<div className="skill-list">
+							<span>AWS</span>
+							<span>EC2</span>
+							<span>S3</span>
+							<span>RDS</span>
+							<span>Docker</span>
+							<span>GitHub Actions</span>
+							<span>CI/CD</span>
+						</div>
+					</div>
+					<div className="skill-card">
+						<div className="skill-head">
+							<span className="ico">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<path d="m21 16-9 5-9-5" />
+									<path d="m21 12-9 5-9-5" />
+									<path d="m12 2 9 5-9 5-9-5 9-5Z" />
+								</svg>
+							</span>
+							<strong>AI Workflow</strong>
+						</div>
+						<div className="skill-list">
+							<span>Claude</span>
+							<span>Cursor</span>
+							<span>Copilot</span>
+							<span>Agent workflows</span>
+							<span>Prompt engineering</span>
+							<span>CLI automation</span>
+						</div>
+					</div>
+					<div className="skill-card">
+						<div className="skill-head">
+							<span className="ico">
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<circle cx="12" cy="12" r="9" />
+									<path d="m9 12 2 2 4-4" />
+								</svg>
+							</span>
+							<strong>Quality &amp; Delivery</strong>
+						</div>
+						<div className="skill-list">
+							<span>Testing</span>
+							<span>Code review</span>
+							<span>Architecture</span>
+							<span>Observability</span>
+							<span>Monitoring</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 }


### PR DESCRIPTION
Complete rebrand of the Next.js portfolio at meherullah.dev — replaces the gradient/blob layout with a CLI/terminal-inspired, agentic-AI-flavored design built on a dark OKLCH design system with soft-purple accents.

The visual language comes from the Claude Design handoff bundle at `/v1/design/h/4jP7ic06ncY79D_8_6DhiA`. Each section was rebuilt as a server or client React component reusing the existing Next.js + Tailwind setup. Theme toggle dropped in favor of dark-only.

## Sections
1. Hero with animated terminal
2. Founder problems (4 ISSUE cards)
3. Build pipeline (8 steps + execution log)
4. Agentic engineering (visual agent flow)
5. Services (8 cards)
6. Projects (aiagentflow, e2spec, SEORanksLab, quick-memorial)
7. Experience (stats + mission log)
8. Skills (6 grouped capability cards)
9. GitHub (heatmap + repo grid)
10. Writing
11. Contact

## Interactions
- Cmd+K command palette
- Hero terminal typing animation
- Scroll-reveal
- Sticky nav

## Build
- tsc --noEmit clean
- next build: 9/9 static pages