### PR TITLE
Implement design3 redesign — tri-accent dark OKLCH system

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,60 +3,94 @@
 @tailwind utilities;
 
 /* ============================================================
-   Portfolio — design tokens (founder-focused rebrand)
+   Portfolio — design tokens
    ============================================================ */
 :root {
-  /* Neutrals — deep cool near-black with violet tint */
-  --bg: oklch(14% 0.012 270);
-  --bg-elev: oklch(17% 0.014 270);
-  --bg-card: oklch(19% 0.015 270);
-  --bg-card-hi: oklch(22% 0.017 270);
-  --border: oklch(28% 0.018 270);
-  --border-hi: oklch(36% 0.025 270);
-  --border-soft: oklch(24% 0.015 270);
+  /* Neutrals — deep warm-ink (a touch of warmth keeps it from feeling clinical) */
+  --bg: oklch(13% 0.014 280);
+  --bg-elev: oklch(17% 0.016 280);
+  --bg-card: oklch(20% 0.018 280);
+  --bg-card-hi: oklch(24% 0.020 280);
+  --border: oklch(30% 0.022 280);
+  --border-hi: oklch(40% 0.028 280);
+  --border-soft: oklch(25% 0.018 280);
+
+  /* Paper interlude (one section flips to a warm cream surface) */
+  --paper: oklch(96% 0.012 80);
+  --paper-elev: oklch(99% 0.008 80);
+  --paper-fg: oklch(22% 0.018 60);
+  --paper-mute: oklch(38% 0.020 60);
+  --paper-border: oklch(82% 0.022 70);
 
   /* Text */
-  --fg: oklch(96% 0.005 270);
-  --fg-mute: oklch(72% 0.012 270);
-  --fg-dim: oklch(55% 0.012 270);
-  --fg-faint: oklch(40% 0.012 270);
+  --fg: oklch(96% 0.006 80);
+  --fg-mute: oklch(74% 0.012 80);
+  --fg-dim: oklch(56% 0.012 80);
+  --fg-faint: oklch(42% 0.012 80);
 
-  /* Accents */
-  --accent: #b794ff;
-  --accent-hi: #d4baff;
-  --accent-soft: rgba(183, 148, 255, 0.14);
-  --accent-line: rgba(183, 148, 255, 0.32);
-  --accent-glow: rgba(183, 148, 255, 0.35);
+  /* Tri-accent system — used semantically across the site
+     · LIME  → build / ship / ok / primary accent
+     · AMBER → human judgment / warn / craft
+     · VIOLET→ AI / agentic / spec
+     Plus blue + coral for chrome and signal.
+  */
+  --lime: #9eff5e;
+  --lime-hi: #c4ff8a;
+  --lime-soft: rgba(158, 255, 94, 0.14);
+  --lime-line: rgba(158, 255, 94, 0.30);
+  --lime-glow: rgba(158, 255, 94, 0.32);
 
-  --green: #4ade80;
-  --green-soft: rgba(74, 222, 128, 0.12);
-  --amber: #fbbf24;
-  --amber-soft: rgba(251, 191, 36, 0.12);
-  --blue: #60a5fa;
-  --blue-soft: rgba(96, 165, 250, 0.12);
-  --red: #f87171;
-  --red-soft: rgba(248, 113, 113, 0.12);
+  --amber: #ffb454;
+  --amber-hi: #ffd089;
+  --amber-soft: rgba(255, 180, 84, 0.14);
+  --amber-line: rgba(255, 180, 84, 0.30);
 
+  --violet: #b794ff;
+  --violet-hi: #d4baff;
+  --violet-soft: rgba(183, 148, 255, 0.14);
+  --violet-line: rgba(183, 148, 255, 0.30);
+
+  --blue: #6db5ff;
+  --blue-soft: rgba(109, 181, 255, 0.12);
+  --coral: #ff8a5b;
+  --coral-soft: rgba(255, 138, 91, 0.12);
+  --red: #ff6b6b;
+  --red-soft: rgba(255, 107, 107, 0.12);
+  --green: var(--lime);
+  --green-soft: var(--lime-soft);
+
+  /* Active accent — the Tweaks panel rewrites this so chrome that should
+     follow a single color (CTAs, borders, prompt) reads as one brand color. */
+  --accent: var(--lime);
+  --accent-hi: var(--lime-hi);
+  --accent-soft: var(--lime-soft);
+  --accent-line: var(--lime-line);
+  --accent-glow: var(--lime-glow);
+
+  /* Type */
   --font-sans: "Geist", "Inter", system-ui, -apple-system, sans-serif;
   --font-mono: "Geist Mono", "JetBrains Mono", ui-monospace, monospace;
 
+  /* Radii */
   --r-sm: 6px;
   --r-md: 10px;
   --r-lg: 14px;
   --r-xl: 20px;
 
+  /* Layout */
   --max: 1240px;
   --pad-x: clamp(20px, 5vw, 56px);
 }
 
-/* Reset + base */
+/* ============================================================
+   Reset + base
+   ============================================================ */
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
 html, body { margin: 0; padding: 0; }
 body {
-  background: var(--bg) !important;
-  color: var(--fg) !important;
-  font-family: var(--font-sans) !important;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-sans);
   font-feature-settings: "ss01", "cv11";
   font-size: 16px;
   line-height: 1.5;
@@ -78,31 +112,42 @@ body::before {
   z-index: 0;
 }
 
-/* Soft top glow */
+/* Soft top glow — two-tone (lime + violet) for a richer ambient field */
 body::after {
   content: "";
   position: fixed;
-  top: -300px;
+  top: -340px;
   left: 50%;
   transform: translateX(-50%);
-  width: 1200px;
-  height: 600px;
-  background: radial-gradient(ellipse at center, var(--accent-soft) 0%, transparent 60%);
+  width: 1400px;
+  height: 720px;
+  background:
+    radial-gradient(ellipse 60% 70% at 35% 50%, var(--lime-soft) 0%, transparent 65%),
+    radial-gradient(ellipse 50% 60% at 70% 40%, var(--violet-soft) 0%, transparent 65%);
   filter: blur(40px);
   pointer-events: none;
   z-index: 0;
-  opacity: 0.6;
+  opacity: 0.7;
 }
 
 a { color: inherit; text-decoration: none; }
 button { font-family: inherit; cursor: pointer; }
 ::selection { background: var(--accent-soft); color: var(--accent-hi); }
 
+/* Defensive SVG sizing \u2014 unconstrained inline SVGs render at 300\u00d7150 in flex
+   layouts and break the page. Cap them to a sensible default unless a parent
+   explicitly sizes them. */
+svg { width: 1em; height: 1em; flex: none; display: inline-block; vertical-align: middle; }
+.btn svg, .gh-bar > svg, .agent-icon svg, .skill-head .ico svg, .service-ico svg,
+.channel-ico svg, .nav-search svg, .cp-input-row > svg, .cp-ico svg,
+.project-folder svg, .writing-row .arrow svg, .hero-cta svg { width: 16px; height: 16px; }
+.term-tab svg { width: 12px; height: 12px; }
+
 /* ============================================================
    Layout primitives
    ============================================================ */
 .app { position: relative; z-index: 1; }
-.container-x {
+.container {
   max-width: var(--max);
   margin: 0 auto;
   padding: 0 var(--pad-x);
@@ -135,6 +180,47 @@ button { font-family: inherit; cursor: pointer; }
   box-shadow: 0 0 12px var(--accent-glow);
 }
 .section-eyebrow .num { color: var(--fg-faint); }
+
+/* Per-section accent rotation \u2014 each numbered section header reads in a
+   different signature color so the page has visual rhythm even though every
+   section shares the same dark surface. The active --accent (lime by default,
+   configurable via Tweaks) still drives buttons, links, and primary chrome \u2014
+   these rules just colour the eyebrow + section dot. */
+main > section:nth-of-type(2) .section-eyebrow .num,
+main > section:nth-of-type(2) .section-title em { color: var(--lime-hi); }
+main > section:nth-of-type(2) .section-eyebrow .dot { background: var(--lime); box-shadow: 0 0 12px var(--lime-glow); }
+
+main > section:nth-of-type(3) .section-eyebrow .num,
+main > section:nth-of-type(3) .section-title em { color: var(--blue); }
+main > section:nth-of-type(3) .section-eyebrow .dot { background: var(--blue); box-shadow: 0 0 12px rgba(109,181,255,0.42); }
+
+main > section:nth-of-type(4) .section-eyebrow .num,
+main > section:nth-of-type(4) .section-title em { color: var(--violet-hi); }
+main > section:nth-of-type(4) .section-eyebrow .dot { background: var(--violet); box-shadow: 0 0 12px rgba(183,148,255,0.42); }
+
+main > section:nth-of-type(5) .section-eyebrow .num,
+main > section:nth-of-type(5) .section-title em { color: var(--amber-hi); }
+main > section:nth-of-type(5) .section-eyebrow .dot { background: var(--amber); box-shadow: 0 0 12px rgba(255,180,84,0.42); }
+
+main > section:nth-of-type(6) .section-eyebrow .num,
+main > section:nth-of-type(6) .section-title em { color: var(--coral); }
+main > section:nth-of-type(6) .section-eyebrow .dot { background: var(--coral); box-shadow: 0 0 12px rgba(255,138,91,0.42); }
+
+main > section:nth-of-type(7) .section-eyebrow .num,
+main > section:nth-of-type(7) .section-title em { color: var(--lime-hi); }
+main > section:nth-of-type(7) .section-eyebrow .dot { background: var(--lime); box-shadow: 0 0 12px var(--lime-glow); }
+
+main > section:nth-of-type(8) .section-eyebrow .num,
+main > section:nth-of-type(8) .section-title em { color: var(--violet-hi); }
+main > section:nth-of-type(8) .section-eyebrow .dot { background: var(--violet); box-shadow: 0 0 12px rgba(183,148,255,0.42); }
+
+main > section:nth-of-type(9) .section-eyebrow .num,
+main > section:nth-of-type(9) .section-title em { color: var(--lime-hi); }
+main > section:nth-of-type(9) .section-eyebrow .dot { background: var(--lime); box-shadow: 0 0 12px var(--lime-glow); }
+
+main > section:nth-of-type(10) .section-eyebrow .num,
+main > section:nth-of-type(10) .section-title em { color: var(--blue); }
+main > section:nth-of-type(10) .section-eyebrow .dot { background: var(--blue); box-shadow: 0 0 12px rgba(109,181,255,0.42); }
 .section-title {
   font-size: clamp(28px, 4vw, 44px);
   font-weight: 500;
@@ -172,7 +258,6 @@ button { font-family: inherit; cursor: pointer; }
   transition: all 160ms ease;
   font-family: var(--font-sans);
   white-space: nowrap;
-  cursor: pointer;
 }
 .btn .kbd {
   font-family: var(--font-mono);
@@ -261,7 +346,6 @@ button { font-family: inherit; cursor: pointer; }
   border-radius: 6px;
   color: var(--fg-mute);
   transition: all 150ms ease;
-  cursor: pointer;
 }
 .nav-links a:hover { color: var(--fg); background: var(--bg-card); }
 
@@ -278,7 +362,6 @@ button { font-family: inherit; cursor: pointer; }
   font-size: 12px;
   min-width: 240px;
   transition: all 150ms ease;
-  cursor: pointer;
 }
 .nav-search:hover { border-color: var(--border-hi); color: var(--fg-mute); }
 .nav-search .kbd {
@@ -344,7 +427,6 @@ button { font-family: inherit; cursor: pointer; }
   line-height: 1.02;
   margin: 0 0 24px;
   text-wrap: balance;
-  color: var(--fg);
 }
 .hero h1 .accent {
   color: var(--accent);
@@ -489,7 +571,9 @@ button { font-family: inherit; cursor: pointer; }
   text-transform: uppercase;
 }
 
-/* Problems */
+/* ============================================================
+   Founder problems
+   ============================================================ */
 .problems-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -541,7 +625,6 @@ button { font-family: inherit; cursor: pointer; }
   margin: 0 0 10px;
   letter-spacing: -0.01em;
   line-height: 1.3;
-  color: var(--fg);
 }
 .problem-a {
   color: var(--fg-mute);
@@ -564,7 +647,9 @@ button { font-family: inherit; cursor: pointer; }
   color: var(--fg-mute);
 }
 
-/* Pipeline */
+/* ============================================================
+   Process pipeline
+   ============================================================ */
 .pipeline {
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
@@ -628,6 +713,18 @@ button { font-family: inherit; cursor: pointer; }
   margin: 0;
   line-height: 1.5;
 }
+.pipe-step .arrow {
+  position: absolute;
+  right: -7px; top: 50%;
+  transform: translateY(-50%);
+  width: 14px; height: 14px;
+  background: var(--bg-card);
+  border-top: 1px solid var(--border-soft);
+  border-right: 1px solid var(--border-soft);
+  transform: translateY(-50%) rotate(45deg);
+  z-index: 1;
+}
+.pipe-step:last-child .arrow { display: none; }
 
 .pipeline-log {
   padding: 16px 20px;
@@ -645,7 +742,9 @@ button { font-family: inherit; cursor: pointer; }
 .pipeline-log .tag.warn { color: var(--amber); }
 .pipeline-log .msg { color: var(--fg-mute); }
 
-/* Agentic */
+/* ============================================================
+   Agentic
+   ============================================================ */
 .agentic-grid {
   display: grid;
   grid-template-columns: 1.2fr 1fr;
@@ -657,7 +756,8 @@ button { font-family: inherit; cursor: pointer; }
 .agent-flow {
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
-  background: linear-gradient(180deg, var(--bg-card) 0%, oklch(17% 0.014 270) 100%);
+  background:
+    linear-gradient(180deg, var(--bg-card) 0%, oklch(17% 0.014 270) 100%);
   padding: 28px;
   display: flex;
   flex-direction: column;
@@ -743,7 +843,6 @@ button { font-family: inherit; cursor: pointer; }
   margin: 0 0 16px;
   letter-spacing: -0.015em;
   line-height: 1.2;
-  color: var(--fg);
 }
 .agent-copy p {
   color: var(--fg-mute);
@@ -772,7 +871,9 @@ button { font-family: inherit; cursor: pointer; }
 }
 .agent-principle strong { color: var(--fg); font-weight: 500; }
 
-/* Services */
+/* ============================================================
+   Services
+   ============================================================ */
 .services-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -807,7 +908,6 @@ button { font-family: inherit; cursor: pointer; }
   font-weight: 500;
   margin: 0 0 8px;
   letter-spacing: -0.005em;
-  color: var(--fg);
 }
 .service p {
   margin: 0;
@@ -816,7 +916,9 @@ button { font-family: inherit; cursor: pointer; }
   line-height: 1.55;
 }
 
-/* Projects */
+/* ============================================================
+   Projects
+   ============================================================ */
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -948,7 +1050,9 @@ button { font-family: inherit; cursor: pointer; }
 .project-links a:hover { color: var(--accent); }
 .project-links svg { width: 13px; height: 13px; }
 
-/* Experience */
+/* ============================================================
+   Experience
+   ============================================================ */
 .experience-grid {
   display: grid;
   grid-template-columns: 1fr 1.5fr;
@@ -1024,7 +1128,9 @@ button { font-family: inherit; cursor: pointer; }
   .mission-row .status { justify-self: start; }
 }
 
-/* Skills */
+/* ============================================================
+   Skills
+   ============================================================ */
 .skills-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -1074,7 +1180,9 @@ button { font-family: inherit; cursor: pointer; }
   color: var(--fg-mute);
 }
 
-/* GitHub */
+/* ============================================================
+   GitHub dashboard
+   ============================================================ */
 .gh-card {
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
@@ -1109,10 +1217,10 @@ button { font-family: inherit; cursor: pointer; }
   border-radius: 2px;
   background: oklch(22% 0.013 270);
 }
-.gh-cell.l1 { background: rgba(183, 148, 255, 0.25); }
-.gh-cell.l2 { background: rgba(183, 148, 255, 0.5); }
-.gh-cell.l3 { background: rgba(183, 148, 255, 0.75); }
-.gh-cell.l4 { background: var(--accent); }
+.gh-cell.l1 { background: rgba(158, 255, 94, 0.22); }
+.gh-cell.l2 { background: rgba(158, 255, 94, 0.45); }
+.gh-cell.l3 { background: rgba(158, 255, 94, 0.72); }
+.gh-cell.l4 { background: var(--lime); box-shadow: 0 0 6px rgba(158, 255, 94, 0.4); }
 .gh-graph-meta {
   display: flex;
   justify-content: space-between;
@@ -1152,6 +1260,7 @@ button { font-family: inherit; cursor: pointer; }
   font-size: 13px;
   margin-bottom: 6px;
 }
+.gh-repo-name svg { width: 14px; height: 14px; flex: none; }
 .gh-repo-name .pub {
   margin-left: auto;
   font-size: 10px;
@@ -1187,8 +1296,13 @@ button { font-family: inherit; cursor: pointer; }
 .gh-repo-meta span { display: flex; align-items: center; gap: 4px; }
 .gh-repo-meta svg { width: 11px; height: 11px; }
 
-/* Writing */
-.writing-list { display: flex; flex-direction: column; }
+/* ============================================================
+   Writing
+   ============================================================ */
+.writing-list {
+  display: flex;
+  flex-direction: column;
+}
 .writing-row {
   display: grid;
   grid-template-columns: 100px 1fr auto;
@@ -1210,7 +1324,6 @@ button { font-family: inherit; cursor: pointer; }
   font-weight: 500;
   letter-spacing: -0.01em;
   margin: 0 0 4px;
-  color: var(--fg);
 }
 .writing-row .meta {
   font-family: var(--font-mono);
@@ -1219,7 +1332,7 @@ button { font-family: inherit; cursor: pointer; }
   display: flex; gap: 14px;
 }
 .writing-row .meta .tag { color: var(--accent); }
-.writing-row .arrow-btn {
+.writing-row .arrow {
   width: 32px; height: 32px;
   border: 1px solid var(--border);
   border-radius: 50%;
@@ -1228,19 +1341,21 @@ button { font-family: inherit; cursor: pointer; }
   color: var(--fg-mute);
   transition: all 200ms ease;
 }
-.writing-row:hover .arrow-btn {
+.writing-row:hover .arrow {
   border-color: var(--accent);
   color: var(--accent);
   transform: rotate(-45deg);
 }
-.writing-row .arrow-btn svg { width: 14px; height: 14px; }
+.writing-row .arrow svg { width: 14px; height: 14px; }
 
 @media (max-width: 640px) {
   .writing-row { grid-template-columns: 1fr; gap: 6px; }
-  .writing-row .arrow-btn { display: none; }
+  .writing-row .arrow { display: none; }
 }
 
-/* Contact */
+/* ============================================================
+   Contact
+   ============================================================ */
 .contact {
   padding: clamp(72px, 10vw, 120px) 0;
   position: relative;
@@ -1284,7 +1399,6 @@ button { font-family: inherit; cursor: pointer; }
   margin: 0 0 20px;
   max-width: 720px;
   text-wrap: balance;
-  color: var(--fg);
 }
 .contact h2 em { color: var(--accent); font-style: normal; }
 .contact-sub {
@@ -1342,7 +1456,9 @@ button { font-family: inherit; cursor: pointer; }
   font-weight: 500;
 }
 
-/* Footer */
+/* ============================================================
+   Footer
+   ============================================================ */
 .foot {
   padding: 40px 0 56px;
   border-top: 1px solid var(--border-soft);
@@ -1365,7 +1481,9 @@ button { font-family: inherit; cursor: pointer; }
   box-shadow: 0 0 8px var(--green);
 }
 
-/* Command Palette */
+/* ============================================================
+   Command Palette
+   ============================================================ */
 .cp-backdrop {
   position: fixed;
   inset: 0;
@@ -1465,7 +1583,9 @@ button { font-family: inherit; cursor: pointer; }
   margin: 0 3px;
 }
 
-/* Reveal on scroll */
+/* ============================================================
+   Reveal on scroll
+   ============================================================ */
 .reveal {
   opacity: 0;
   transform: translateY(20px);
@@ -1475,9 +1595,3 @@ button { font-family: inherit; cursor: pointer; }
   opacity: 1;
   transform: none;
 }
-
-/* Scrollbar */
-::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-track { background: var(--bg); }
-::-webkit-scrollbar-thumb { background: var(--border-hi); border-radius: 5px; }
-::-webkit-scrollbar-thumb:hover { background: var(--accent-line); }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { CommandPalette } from "@/components/CommandPalette";
+import { RevealObserver } from "@/components/RevealObserver";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://meherullah.dev/";
 const siteName = "Md Meher Ullah - AI-Augmented Software Engineer";
@@ -111,6 +112,7 @@ export default function RootLayout({
 					<Footer />
 				</div>
 				<CommandPalette />
+				<RevealObserver />
 			</body>
 		</html>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { Projects } from '@/components/Projects'
 import { Experience } from '@/components/Experience'
 import { Skills } from '@/components/Skills'
 import { GitHubDashboard } from '@/components/GitHubDashboard'
-import { BlogPreview } from '@/components/BlogPreview'
+import { Writing } from '@/components/Writing'
 import { Contact } from '@/components/Contact'
 
 export default function Home() {
@@ -22,7 +22,7 @@ export default function Home() {
       <Experience />
       <Skills />
       <GitHubDashboard />
-      <BlogPreview />
+      <Writing />
       <Contact />
     </main>
   )

--- a/src/components/AgenticEngineering.tsx
+++ b/src/components/AgenticEngineering.tsx
@@ -1,140 +1,100 @@
+import { Icon } from '@/components/Icons'
+
+const AGENTS = [
+  { name: 'Founder Goal', role: 'the business outcome we\'re building toward', icon: <Icon.target />, status: 'input', type: '' },
+  { name: 'Architect Agent', role: 'system design, data model, API boundaries', icon: <Icon.layers />, status: 'auto', type: '' },
+  { name: 'Coder Agent', role: 'implements modules under defined contracts', icon: <Icon.builder />, status: 'auto', type: '' },
+  { name: 'Reviewer Agent', role: 'static analysis, style, anti-patterns', icon: <Icon.reviewer />, status: 'auto', type: '' },
+  { name: 'Tester Agent', role: 'writes + runs tests, finds edge cases', icon: <Icon.tester />, status: 'auto', type: '' },
+  { name: 'Human Judgment', role: 'architecture, security, trade-offs, what NOT to build', icon: <Icon.human />, status: 'human', type: 'is-human' },
+  { name: 'Production Release', role: 'shipped, monitored, owned end-to-end', icon: <Icon.rocket />, status: 'ok', type: 'is-output' },
+]
+
 export function AgenticEngineering() {
   return (
-    <section className="section" id="agentic">
-      <div className="container-x">
-        <div className="section-head reveal">
-          <div>
-            <div className="section-eyebrow">
-              <span className="dot"></span>
-              <span className="num">03</span>
-              <span>agentic engineering</span>
-            </div>
-            <h2 className="section-title">
-              AI-assisted, <em>human-owned</em> engineering.
-            </h2>
+    <section className="section container reveal">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">03 /</span> <span className="dot"></span>{' '}
+            <span>signature approach</span>
           </div>
-          <p className="section-sub">
-            Agents move drafts. Humans own decisions. The handoff between
-            them is where most teams get burned &mdash; that&apos;s the part I take
-            care of.
-          </p>
+          <h2 className="section-title">
+            AI-assisted, <em>human-owned</em> engineering.
+          </h2>
         </div>
-
-        <div className="agentic-grid">
-          <div className="agent-flow reveal" aria-hidden="false">
-            <div className="agent-node is-human">
-              <div className="agent-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+        <p className="section-sub">
+          I use AI agents and CLI workflows for leverage — never as autopilot. Founders get faster
+          delivery without losing the engineering quality that keeps a product alive in year two.
+        </p>
+      </div>
+      <div className="agentic-grid">
+        <div className="agent-flow">
+          {AGENTS.map((a, i) => (
+            <>
+              <div className={'agent-node ' + a.type} key={i}>
+                <div className="agent-icon">{a.icon}</div>
+                <div style={{ minWidth: 0 }}>
+                  <div className="agent-name">{a.name}</div>
+                  <div className="agent-role">{a.role}</div>
+                </div>
+                <div
+                  className={
+                    'agent-status ' +
+                    (a.status === 'ok' ? 'ok' : a.status === 'human' ? 'human' : '')
+                  }
+                >
+                  <span className="dot"></span> {a.status}
+                </div>
               </div>
-              <div>
-                <div className="agent-name">founder.goal</div>
-                <div className="agent-role">What outcome are we shipping?</div>
-              </div>
-              <div className="agent-status human"><span className="dot"></span>input</div>
+              {i < AGENTS.length - 1 && <div className="agent-arrow" key={'arrow-' + i}></div>}
+            </>
+          ))}
+        </div>
+        <div className="agent-copy">
+          <h3>Speed without losing the plot.</h3>
+          <p>
+            The AI handles the volume work — boilerplate, scaffolds, drafts, test stubs. I handle
+            the decisions that matter: what to build, how to structure it, what to refuse to build,
+            and when &ldquo;the agent&rsquo;s suggestion&rdquo; is actually a maintenance bomb six
+            months out.
+          </p>
+          <p>
+            Founders don&rsquo;t need a pure prompter or a pure engineer. They need someone who can
+            hold both.
+          </p>
+          <div className="agent-principles">
+            <div className="agent-principle">
+              <span className="pn">01.</span>
+              <span>
+                <strong>AI for speed,</strong> not for judgment. Architecture and trade-offs stay
+                human.
+              </span>
             </div>
-            <span className="agent-arrow"></span>
-
-            <div className="agent-node">
-              <div className="agent-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5"/><path d="m21 12-9 5-9-5"/><path d="m12 2 9 5-9 5-9-5 9-5Z"/></svg>
-              </div>
-              <div>
-                <div className="agent-name">architect.agent</div>
-                <div className="agent-role">data model &middot; API contracts &middot; constraints</div>
-              </div>
-              <div className="agent-status ok"><span className="dot"></span>ready</div>
+            <div className="agent-principle">
+              <span className="pn">02.</span>
+              <span>
+                <strong>Every output gets reviewed.</strong> If I wouldn&rsquo;t merge it from a
+                junior, I don&rsquo;t merge it from an agent.
+              </span>
             </div>
-            <span className="agent-arrow"></span>
-
-            <div className="agent-node">
-              <div className="agent-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-              </div>
-              <div>
-                <div className="agent-name">coder.agent</div>
-                <div className="agent-role">drafts typed full-stack implementation</div>
-              </div>
-              <div className="agent-status ok"><span className="dot"></span>running</div>
+            <div className="agent-principle">
+              <span className="pn">03.</span>
+              <span>
+                <strong>Tests are the contract.</strong> Generated code earns trust the same way
+                human code does.
+              </span>
             </div>
-            <span className="agent-arrow"></span>
-
-            <div className="agent-node">
-              <div className="agent-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m9 12 2 2 4-4"/></svg>
-              </div>
-              <div>
-                <div className="agent-name">reviewer.agent</div>
-                <div className="agent-role">static analysis &middot; security &middot; diffs</div>
-              </div>
-              <div className="agent-status ok"><span className="dot"></span>passed</div>
-            </div>
-            <span className="agent-arrow"></span>
-
-            <div className="agent-node">
-              <div className="agent-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-              </div>
-              <div>
-                <div className="agent-name">tester.agent</div>
-                <div className="agent-role">unit + integration on real DBs</div>
-              </div>
-              <div className="agent-status ok"><span className="dot"></span>green</div>
-            </div>
-            <span className="agent-arrow"></span>
-
-            <div className="agent-node is-human">
-              <div className="agent-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg>
-              </div>
-              <div>
-                <div className="agent-name">human.judgment</div>
-                <div className="agent-role">architecture &amp; trade-offs &middot; the part that matters</div>
-              </div>
-              <div className="agent-status human"><span className="dot"></span>me</div>
-            </div>
-            <span className="agent-arrow"></span>
-
-            <div className="agent-node is-output">
-              <div className="agent-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7"/><path d="M16 6l-4-4-4 4"/><path d="M12 2v14"/></svg>
-              </div>
-              <div>
-                <div className="agent-name">production.release</div>
-                <div className="agent-role">shipped &middot; monitored &middot; accountable</div>
-              </div>
-              <div className="agent-status ok"><span className="dot"></span>live</div>
-            </div>
-          </div>
-
-          <div className="agent-copy reveal">
-            <h3>I use AI as leverage. I don&apos;t outsource judgment to it.</h3>
-            <p>
-              Agents draft code fast. They also confidently produce subtle
-              bugs, security holes, and architectures that don&apos;t survive
-              contact with real users. I keep humans in the loop where it
-              counts.
-            </p>
-            <div className="agent-principles">
-              <div className="agent-principle">
-                <span className="pn">01</span>
-                <span><strong>Architecture is owned.</strong> Data models, service boundaries, and trade-offs are decided deliberately &mdash; not whatever the model felt like emitting.</span>
-              </div>
-              <div className="agent-principle">
-                <span className="pn">02</span>
-                <span><strong>Every diff is read.</strong> AI-generated code goes through the same review bar as anything I&apos;d write by hand.</span>
-              </div>
-              <div className="agent-principle">
-                <span className="pn">03</span>
-                <span><strong>Tests on real infrastructure.</strong> Mocked tests aren&apos;t proof &mdash; integration tests against real databases are.</span>
-              </div>
-              <div className="agent-principle">
-                <span className="pn">04</span>
-                <span><strong>Maintainability over cleverness.</strong> If the next engineer can&apos;t read it in a week, it doesn&apos;t ship.</span>
-              </div>
+            <div className="agent-principle">
+              <span className="pn">04.</span>
+              <span>
+                <strong>Boring works.</strong> Postgres, queues, monoliths — chosen on merit, not
+                novelty.
+              </span>
             </div>
           </div>
         </div>
       </div>
     </section>
-  );
+  )
 }

--- a/src/components/BuildProcess.tsx
+++ b/src/components/BuildProcess.tsx
@@ -1,92 +1,70 @@
+const PROCESS_STEPS = [
+  { idx: '01', name: 'Idea', desc: 'Understand the business goal, users, and constraints.' },
+  { idx: '02', name: 'Spec', desc: 'Translate into clear, developer-ready scope and tasks.' },
+  { idx: '03', name: 'Architect', desc: 'Data model, API boundaries, auth, infra plan.' },
+  { idx: '04', name: 'UI', desc: 'Frontend with React / Next.js. Real interactions, not mockups.' },
+  { idx: '05', name: 'Backend', desc: 'Node.js / NestJS. APIs, jobs, integrations, data.' },
+  { idx: '06', name: 'Test', desc: 'Jest, Cypress, integration, manual smoke. Real coverage.' },
+  { idx: '07', name: 'Ship', desc: 'Docker, AWS, CI/CD. Observability before launch.' },
+  { idx: '08', name: 'Iterate', desc: 'Read logs, listen to users, improve what matters.' },
+]
+
+const PROCESS_LOG = [
+  { ts: '10:24:11', tag: 'info', txt: 'discovery call · 45min · captured 12 user stories' },
+  { ts: '10:24:18', tag: 'ok', txt: 'spec.md generated · 6 milestones · 38 tickets' },
+  { ts: '10:24:22', tag: 'info', txt: 'architecture: monolith → modular, Postgres, S3, queue worker' },
+  { ts: '10:24:31', tag: 'ok', txt: 'ci/cd: github actions → ECS · zero-downtime deploys configured' },
+  { ts: '10:24:39', tag: 'warn', txt: 'ai-suggested cache layer rejected · simpler memoization sufficient' },
+  { ts: '10:24:44', tag: 'ok', txt: 'production: monitored · 99.8% uptime · ready for users' },
+]
+
 export function BuildProcess() {
   return (
-    <section className="section" id="process">
-      <div className="container-x">
-        <div className="section-head reveal">
-          <div>
-            <div className="section-eyebrow">
-              <span className="dot"></span>
-              <span className="num">02</span>
-              <span>build pipeline</span>
-            </div>
-            <h2 className="section-title">
-              From idea to shipped product, <em>step by step.</em>
-            </h2>
+    <section className="section container reveal" id="process">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">02 /</span> <span className="dot"></span>{' '}
+            <span>build process</span>
           </div>
-          <p className="section-sub">
-            A repeatable pipeline for founders who want clarity at every
-            stage &mdash; not just a black-box &ldquo;we&rsquo;ll get it done&rdquo;.
-          </p>
+          <h2 className="section-title">
+            From idea to shipped product — <em>without skipping steps.</em>
+          </h2>
         </div>
-
-        <div className="pipeline reveal">
-          <div className="pipeline-bar">
-            <span className="dot ok"></span>
-            <span><strong>pipeline</strong> &middot; idea &rarr; production</span>
-            <span className="path">build/founder-engagement.yml</span>
-            <span className="ts">runtime &middot; weeks, not months</span>
-          </div>
-
-          <div className="pipeline-steps">
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>01 &middot; idea</div>
-              <h4>clarify</h4>
-              <p>Sharpen the goal, users, and constraints.</p>
-              <span className="arrow"></span>
+        <p className="section-sub">
+          Eight stages. None of them get hand-waved away. AI helps; it doesn&apos;t replace any of
+          them.
+        </p>
+      </div>
+      <div className="pipeline">
+        <div className="pipeline-bar">
+          <span className="dot ok"></span>
+          <span>pipeline · default-branch</span>
+          <span className="path">/ build-process.yml</span>
+          <span className="ts">last run: 2m ago · all stages passing</span>
+        </div>
+        <div className="pipeline-steps">
+          {PROCESS_STEPS.map((s) => (
+            <div className="pipe-step" key={s.idx}>
+              <div className="idx">
+                <span className="ind"></span> stage {s.idx}
+              </div>
+              <h4>{s.name}</h4>
+              <p>{s.desc}</p>
+              <div className="arrow"></div>
             </div>
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>02 &middot; spec</div>
-              <h4>scope</h4>
-              <p>Developer-ready tasks &amp; milestones.</p>
-              <span className="arrow"></span>
+          ))}
+        </div>
+        <div className="pipeline-log">
+          {PROCESS_LOG.map((l, i) => (
+            <div className="row" key={i}>
+              <span className="ts">[{l.ts}]</span>
+              <span className={'tag ' + l.tag}>{l.tag.toUpperCase().padEnd(6, ' ')}</span>
+              <span className="msg">{l.txt}</span>
             </div>
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>03 &middot; arch</div>
-              <h4>design</h4>
-              <p>System, data, API boundaries.</p>
-              <span className="arrow"></span>
-            </div>
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>04 &middot; ui</div>
-              <h4>build</h4>
-              <p>Next.js / React product interfaces.</p>
-              <span className="arrow"></span>
-            </div>
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>05 &middot; api</div>
-              <h4>wire</h4>
-              <p>NestJS / Node services &amp; Postgres.</p>
-              <span className="arrow"></span>
-            </div>
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>06 &middot; test</div>
-              <h4>verify</h4>
-              <p>Unit + integration, real DBs.</p>
-              <span className="arrow"></span>
-            </div>
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>07 &middot; ship</div>
-              <h4>deploy</h4>
-              <p>AWS, Docker, CI/CD.</p>
-              <span className="arrow"></span>
-            </div>
-            <div className="pipe-step">
-              <div className="idx"><span className="ind"></span>08 &middot; loop</div>
-              <h4>monitor</h4>
-              <p>Logs, metrics, real user feedback.</p>
-            </div>
-          </div>
-
-          <div className="pipeline-log">
-            <div className="row"><span className="ts">00:00.12</span><span className="tag info">info</span><span className="msg">discovery call &middot; founder goal captured</span></div>
-            <div className="row"><span className="ts">00:01.43</span><span className="tag info">spec</span><span className="msg">requirements &rarr; tasks &middot; estimate locked</span></div>
-            <div className="row"><span className="ts">00:02.07</span><span className="tag ok">ok</span><span className="msg">architecture &middot; postgres schema + REST boundary signed off</span></div>
-            <div className="row"><span className="ts">00:04.51</span><span className="tag info">build</span><span className="msg">next.js shell + auth + dashboards landed</span></div>
-            <div className="row"><span className="ts">00:05.18</span><span className="tag warn">review</span><span className="msg">human-in-the-loop pass &middot; 3 AI suggestions rejected</span></div>
-            <div className="row"><span className="ts">00:06.02</span><span className="tag ok">deploy</span><span className="msg">aws &middot; zero-downtime cut &middot; monitoring green</span></div>
-          </div>
+          ))}
         </div>
       </div>
     </section>
-  );
+  )
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,65 +1,54 @@
+import { Icon } from '@/components/Icons'
+
+const CHANNELS = [
+  { ico: <Icon.mail />, label: 'email', val: 'meherullah97@gmail.com', href: 'mailto:meherullah97@gmail.com' },
+  { ico: <Icon.linkedin />, label: 'linkedin', val: '/in/raajkhan', href: 'https://www.linkedin.com/in/raajkhan/' },
+  { ico: <Icon.github />, label: 'github', val: '@raj-khan', href: 'https://github.com/raj-khan' },
+  { ico: <Icon.download />, label: 'cv', val: 'Download (PDF)', href: '/Meher Ullah - Full-Stack Software Engineer.pdf' },
+]
+
 export function Contact() {
   return (
-    <section className="contact" id="contact">
-      <div className="container reveal">
-        <div className="contact-card">
-          <div className="contact-prompt">
-            <span className="prompt" style={{ color: 'var(--accent)' }}>$</span>
-            <span>founder build --with meher</span>
-          </div>
-          <h2>
-            Have an idea you want to turn <em>into software?</em>
-          </h2>
-          <p className="contact-sub">
-            If you&apos;re a founder, startup, or engineering team with a
-            product idea, technical challenge, or AI workflow problem —
-            I can help you clarify it, build it, and ship it.
-          </p>
-          <div className="contact-actions">
-            <a className="btn btn-primary" href="mailto:meherullah97@gmail.com">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>
-              Email me
-            </a>
-            <a className="btn btn-ghost" href="https://www.linkedin.com/in/raajkhan/" target="_blank" rel="noopener">
-              Connect on LinkedIn
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
-            </a>
-            <a className="btn btn-ghost" href="https://github.com/raj-khan" target="_blank" rel="noopener">
-              View GitHub
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M7 17 17 7"/><path d="M7 7h10v10"/></svg>
-            </a>
-          </div>
-
-          <div className="contact-channels">
-            <a className="channel" href="mailto:meherullah97@gmail.com">
-              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg></div>
+    <section className="contact container reveal" id="contact">
+      <div className="contact-card">
+        <div className="contact-prompt">
+          <span>$ founder contact --to meher</span>
+          <span
+            className="term-cursor"
+            style={{ display: 'inline-block', width: 7, height: 13, background: 'var(--accent)', verticalAlign: -1 }}
+          ></span>
+        </div>
+        <h2>
+          Got an idea you want to turn into <em>real software?</em>
+        </h2>
+        <p className="contact-sub">
+          If you&apos;re a founder, startup, or team with a product idea, an AI workflow problem,
+          or a build that&apos;s stalled — let&apos;s talk. I reply within a day, in your timezone.
+        </p>
+        <div className="contact-actions">
+          <a className="btn btn-primary" href="mailto:meherullah97@gmail.com">
+            <Icon.send /> Send an email <Icon.arrowRight />
+          </a>
+          <a className="btn btn-ghost" href="https://www.linkedin.com/in/raajkhan/" target="_blank" rel="noopener">
+            Connect on LinkedIn
+          </a>
+        </div>
+        <div className="contact-channels">
+          {CHANNELS.map((c, i) => (
+            <a
+              className="channel"
+              key={i}
+              href={c.href}
+              target={c.href.startsWith('http') ? '_blank' : undefined}
+              rel="noopener"
+            >
+              <span className="channel-ico">{c.ico}</span>
               <div>
-                <div className="channel-label">Email</div>
-                <div className="channel-val">meherullah97@gmail.com</div>
+                <div className="channel-label">{c.label}</div>
+                <div className="channel-val">{c.val}</div>
               </div>
             </a>
-            <a className="channel" href="https://www.linkedin.com/in/raajkhan/" target="_blank" rel="noopener">
-              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4 4h4v16H4zM6 2a2 2 0 1 1 0 4 2 2 0 0 1 0-4Zm5 6h4v2.2c.6-1 2-2.4 4.2-2.4 4.5 0 5.3 3 5.3 6.8V20h-4v-6.2c0-1.5 0-3.4-2.1-3.4S16 12 16 13.8V20h-4Z"/></svg></div>
-              <div>
-                <div className="channel-label">LinkedIn</div>
-                <div className="channel-val">linkedin.com/raajkhan</div>
-              </div>
-            </a>
-            <a className="channel" href="https://github.com/raj-khan" target="_blank" rel="noopener">
-              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg></div>
-              <div>
-                <div className="channel-label">GitHub</div>
-                <div className="channel-val">github.com/raj-khan</div>
-              </div>
-            </a>
-            <a className="channel" href="/Meher Ullah - Full-Stack Software Engineer.pdf" target="_blank" rel="noopener">
-              <div className="channel-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></div>
-              <div>
-                <div className="channel-label">CV</div>
-                <div className="channel-val">Download (PDF)</div>
-              </div>
-            </a>
-          </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,97 +1,65 @@
+const STATS = [
+  { num: '8', small: '+ yrs', label: 'shipping production code' },
+  { num: '30', small: '+', label: 'products & features in production' },
+  { num: '12', small: '', label: 'enterprise & client teams' },
+  { num: '5', small: '+', label: 'open-source projects maintained' },
+]
+
+const MISSIONS = [
+  { when: '2023 — now', what: 'Full-stack engineer', where: 'Snappymob · Kuala Lumpur', status: 'active' },
+  { when: '2020 — 2023', what: 'Senior software engineer', where: 'Enterprise SaaS & financial systems', status: 'done' },
+  { when: '2018 — 2020', what: 'Full-stack engineer', where: 'Product & client work, MVPs & dashboards', status: 'done' },
+  { when: '2017 — 2018', what: 'Software engineer', where: 'Backend services & integrations', status: 'done' },
+  { when: 'Ongoing', what: 'Independent / open-source', where: 'aiagentflow, e2spec, dev-workflow tooling', status: 'active' },
+]
+
 export function Experience() {
-	return (
-		<section className="section" id="experience">
-			<div className="container-x">
-				<div className="section-head reveal">
-					<div>
-						<div className="section-eyebrow">
-							<span className="dot"></span>
-							<span className="num">06</span>
-							<span>mission log</span>
-						</div>
-						<h2 className="section-title">
-							Eight years of{" "}
-							<em>shipping software in production.</em>
-						</h2>
-					</div>
-					<p className="section-sub">
-						Enterprise systems, SaaS products, and internal tools — owned
-						end-to-end across frontend, backend, and infrastructure.
-					</p>
-				</div>
-
-				<div className="experience-grid">
-					<div className="stats-grid reveal">
-						<div className="stat">
-							<div className="stat-num">
-								8<span className="small">+</span>
-							</div>
-							<div className="stat-label">years shipping</div>
-						</div>
-						<div className="stat">
-							<div className="stat-num">
-								40<span className="small">%</span>
-							</div>
-							<div className="stat-label">
-								response-time gain · scaling work
-							</div>
-						</div>
-						<div className="stat">
-							<div className="stat-num">4</div>
-							<div className="stat-label">production stacks owned</div>
-						</div>
-						<div className="stat">
-							<div className="stat-num">0</div>
-							<div className="stat-label">
-								days of prod downtime · post-scaling
-							</div>
-						</div>
-					</div>
-
-					<div className="mission-log reveal">
-						<div className="mission-row">
-							<span className="when">2022 — now</span>
-							<span className="what">
-								<strong>Senior Software Engineer</strong>
-								<span className="where">
-									Snappymob · Kuala Lumpur, Malaysia
-								</span>
-							</span>
-							<span className="status status-active">Active</span>
-						</div>
-						<div className="mission-row">
-							<span className="when">2022</span>
-							<span className="what">
-								<strong>PHP Developer</strong>
-								<span className="where">
-									Wipro Bangladesh Limited · Dhaka
-								</span>
-							</span>
-							<span className="status status-done">Done</span>
-						</div>
-						<div className="mission-row">
-							<span className="when">2019 — 2022</span>
-							<span className="what">
-								<strong>Software Developer</strong>
-								<span className="where">
-									SCT-Bangla Limited · Dhaka
-								</span>
-							</span>
-							<span className="status status-done">Done</span>
-						</div>
-						<div className="mission-row">
-							<span className="when">2017 — 2019</span>
-							<span className="what">
-								<strong>Full-Stack Web Developer</strong>
-								<span className="where">
-									Bangladesh Software Development (BSD) · Dhaka
-								</span>
-							</span>
-							<span className="status status-done">Done</span>
-						</div>
-					</div>
-				</div>
-			</div>
-		</section>
-	);
+  return (
+    <section className="section container reveal">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">06 /</span> <span className="dot"></span>{' '}
+            <span>mission log</span>
+          </div>
+          <h2 className="section-title">
+            Eight years. <em>Real production. Real users.</em>
+          </h2>
+        </div>
+        <p className="section-sub">
+          No bootcamps, no buzzword resumes. Just shipped systems that customers paid for or relied
+          on.
+        </p>
+      </div>
+      <div className="experience-grid">
+        <div>
+          <div className="stats-grid">
+            {STATS.map((s, i) => (
+              <div className="stat" key={i}>
+                <div className="stat-num">
+                  {s.num}
+                  <span className="small">{s.small}</span>
+                </div>
+                <div className="stat-label">{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="mission-log">
+          {MISSIONS.map((m, i) => (
+            <div className="mission-row" key={i}>
+              <div className="when">{m.when}</div>
+              <div className="what">
+                <strong>{m.what}</strong>
+                <span className="where">{m.where}</span>
+              </div>
+              <div className={'status status-' + m.status}>
+                {m.status === 'active' ? '● active' : '○ shipped'}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
 }

--- a/src/components/FounderProblems.tsx
+++ b/src/components/FounderProblems.tsx
@@ -1,99 +1,77 @@
+type Problem = {
+  issue: string
+  state: string
+  q: string
+  a: string
+  tags: string[]
+}
+
+const PROBLEMS: Problem[] = [
+  {
+    issue: 'ISSUE-001',
+    state: 'open',
+    q: 'You have an idea but no technical roadmap.',
+    a: 'I turn rough product concepts into clear specs, system architecture, and an MVP plan you can actually ship — without 6 weeks of slideware.',
+    tags: ['discovery', 'specs', 'architecture'],
+  },
+  {
+    issue: 'ISSUE-002',
+    state: 'open',
+    q: 'Your MVP is slow, messy, or hard to extend.',
+    a: 'I refactor full-stack codebases, stabilise CI/CD, fix the data model, and bring the system back into a state where adding features is fast again.',
+    tags: ['refactor', 'stability', 'speed'],
+  },
+  {
+    issue: 'ISSUE-003',
+    state: 'open',
+    q: 'You need someone who can own the whole build.',
+    a: "Frontend, backend, database, cloud, auth, deploy, monitoring — one technical partner instead of coordinating three contractors who don’t talk to each other.",
+    tags: ['full-stack', 'ownership', 'delivery'],
+  },
+  {
+    issue: 'ISSUE-004',
+    state: 'open',
+    q: 'You want AI leverage without AI chaos.',
+    a: "I use Claude, Cursor, and agent CLIs daily — but every output gets reviewed, tested, and architected by a human who’s been shipping for 8 years.",
+    tags: ['ai-assisted', 'review', 'judgment'],
+  },
+]
+
 export function FounderProblems() {
   return (
-    <section className="section" id="founder-problems">
-      <div className="container-x">
-        <div className="section-head reveal">
-          <div>
-            <div className="section-eyebrow">
-              <span className="dot" aria-hidden="true"></span>
-              <span className="num">01</span>
-              <span>where I help most</span>
-            </div>
-            <h2 className="section-title">
-              Problems founders bring me <em>&mdash; and how I solve them.</em>
-            </h2>
+    <section className="section container reveal" id="work">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">01 /</span> <span className="dot"></span>{' '}
+            <span>where i help most</span>
           </div>
-          <p className="section-sub">
-            You don&apos;t need another contractor who only writes code. You
-            need a technical partner who can think with you about
-            product, architecture, and delivery.
-          </p>
+          <h2 className="section-title">The four problems I get hired to solve.</h2>
         </div>
-
-        <div className="problems-grid reveal">
-          <article className="problem">
+        <p className="section-sub">
+          Most founders I work with land on one of these. If any sound familiar, we should talk.
+        </p>
+      </div>
+      <div className="problems-grid">
+        {PROBLEMS.map((p, i) => (
+          <div className="problem" key={i}>
             <div className="problem-issue">
-              <span className="badge">ISSUE #01</span>
-              <span>no technical roadmap</span>
+              <span>{p.issue}</span>
+              <span className="badge">{p.state}</span>
+              <span style={{ marginLeft: 'auto' }}>· assigned: @meher</span>
             </div>
-            <h3 className="problem-q">You have a clear idea, but no path to a working product.</h3>
-            <p className="problem-a">
-              I translate fuzzy product ideas into developer-ready
-              requirements, an architecture sketch, and an honest delivery
-              plan you can ship from.
-            </p>
+            <h3 className="problem-q">{p.q}</h3>
+            <p className="problem-a">{p.a}</p>
             <div className="problem-tags">
-              <span className="problem-tag">discovery</span>
-              <span className="problem-tag">spec</span>
-              <span className="problem-tag">roadmap</span>
+              {p.tags.map((t) => (
+                <span className="problem-tag" key={t}>
+                  {t}
+                </span>
+              ))}
             </div>
-          </article>
-
-          <article className="problem">
-            <div className="problem-issue">
-              <span className="badge">ISSUE #02</span>
-              <span>messy MVP</span>
-            </div>
-            <h3 className="problem-q">Your MVP works, but it&apos;s slow, fragile, or hard to extend.</h3>
-            <p className="problem-a">
-              I stabilize and refactor full-stack apps &mdash; database, APIs,
-              frontend &mdash; so you can grow on top of them instead of around
-              them.
-            </p>
-            <div className="problem-tags">
-              <span className="problem-tag">refactor</span>
-              <span className="problem-tag">performance</span>
-              <span className="problem-tag">postgres</span>
-            </div>
-          </article>
-
-          <article className="problem">
-            <div className="problem-issue">
-              <span className="badge">ISSUE #03</span>
-              <span>fractured ownership</span>
-            </div>
-            <h3 className="problem-q">You need one person who can own the whole build.</h3>
-            <p className="problem-a">
-              Frontend, backend, cloud, CI/CD, product decisions &mdash; I run
-              the whole stack so you don&apos;t have to coordinate five
-              vendors to ship one feature.
-            </p>
-            <div className="problem-tags">
-              <span className="problem-tag">full-stack</span>
-              <span className="problem-tag">aws</span>
-              <span className="problem-tag">ci/cd</span>
-            </div>
-          </article>
-
-          <article className="problem">
-            <div className="problem-issue">
-              <span className="badge">ISSUE #04</span>
-              <span>AI without chaos</span>
-            </div>
-            <h3 className="problem-q">You want to use AI without shipping broken code.</h3>
-            <p className="problem-a">
-              I use agents and CLI workflows for speed, but with review,
-              testing, and engineering judgment in the loop. AI is
-              leverage &mdash; not a substitute for ownership.
-            </p>
-            <div className="problem-tags">
-              <span className="problem-tag">agents</span>
-              <span className="problem-tag">review</span>
-              <span className="problem-tag">testing</span>
-            </div>
-          </article>
-        </div>
+          </div>
+        ))}
       </div>
     </section>
-  );
+  )
 }

--- a/src/components/GitHubDashboard.tsx
+++ b/src/components/GitHubDashboard.tsx
@@ -1,129 +1,121 @@
-'use client'
+import { Icon } from '@/components/Icons'
 
-import { useEffect, useRef } from 'react'
+function genGraph() {
+  const cells: number[] = []
+  let seed = 42
+  const rand = () => {
+    seed = (seed * 9301 + 49297) % 233280
+    return seed / 233280
+  }
+  for (let w = 0; w < 53; w++) {
+    for (let d = 0; d < 7; d++) {
+      const recencyBoost = w > 38 ? 0.4 : w > 20 ? 0.15 : 0
+      const r = rand() + recencyBoost - (d === 0 || d === 6 ? 0.2 : 0)
+      let lvl = 0
+      if (r > 0.85) lvl = 4
+      else if (r > 0.65) lvl = 3
+      else if (r > 0.45) lvl = 2
+      else if (r > 0.28) lvl = 1
+      cells.push(lvl)
+    }
+  }
+  return cells
+}
+const GRAPH = genGraph()
+
+const REPOS = [
+  { name: 'aiagentflow', desc: 'Local-first CLI orchestrator for multi-agent software engineering workflows.', lang: 'TypeScript', langColor: '#3178c6', stars: 142, forks: 21 },
+  { name: 'e2spec', desc: 'Turn rough product ideas into developer-ready specs, milestones, and tickets.', lang: 'TypeScript', langColor: '#3178c6', stars: 88, forks: 9 },
+  { name: 'claude-cli-recipes', desc: 'Practical Claude/Cursor recipes for real codebases — not demos.', lang: 'Shell', langColor: '#89e051', stars: 56, forks: 7 },
+  { name: 'nestjs-prod-starter', desc: 'Opinionated NestJS starter: auth, queues, OpenAPI, Docker, ECS-ready.', lang: 'TypeScript', langColor: '#3178c6', stars: 34, forks: 5 },
+]
 
 export function GitHubDashboard() {
-  const graphRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    const graph = graphRef.current
-    if (!graph) return
-    const total = 53 * 7
-    let frag = ''
-    for (let i = 0; i < total; i++) {
-      const seed = (i * 9301 + 49297) % 233280
-      const r = seed / 233280
-      const week = Math.floor(i / 7)
-      const recent = week > 36 ? 0.25 : 0
-      const v = r + recent
-      let cls = ''
-      if (v > 0.92) cls = 'l4'
-      else if (v > 0.78) cls = 'l3'
-      else if (v > 0.6) cls = 'l2'
-      else if (v > 0.4) cls = 'l1'
-      frag += `<div class="gh-cell ${cls}"></div>`
-    }
-    graph.innerHTML = frag
-  }, [])
-
   return (
-    <section className="section" id="github">
-      <div className="container">
-        <div className="section-head reveal">
-          <div>
-            <div className="section-eyebrow">
-              <span className="dot"></span>
-              <span className="num">08</span>
-              <span>open-source</span>
-            </div>
-            <h2 className="section-title">
-              I build &amp; experiment <em>in public.</em>
-            </h2>
+    <section className="section container reveal" id="github">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">08 /</span> <span className="dot"></span>{' '}
+            <span>open source</span>
           </div>
-          <p className="section-sub">
-            Especially around AI-assisted software engineering, CLI
-            tools, and developer workflows.
-          </p>
+          <h2 className="section-title">
+            I build &amp; experiment <em>in public.</em>
+          </h2>
         </div>
-
-        <div className="gh-card reveal">
-          <div className="gh-bar">
-            <span><span className="at">@</span>raj-khan</span>
-            <span className="where">github.com/raj-khan</span>
-            <span className="followers">
-              <span><b>Repos</b> · public</span>
-              <span><b>Focus</b> · agentic + full-stack</span>
+        <p className="section-sub">
+          Especially around AI-assisted engineering, CLI tools, and developer workflows. Hire
+          someone who shows their work.
+        </p>
+      </div>
+      <div className="gh-card">
+        <div className="gh-bar">
+          <Icon.github />
+          <span className="at">@raj-khan</span>
+          <span className="where">/ contributions last year</span>
+          <div className="followers">
+            <span>
+              <b>1,284</b> commits
+            </span>
+            <span>
+              <b>47</b> followers
+            </span>
+            <span>
+              <b>312</b> stars
             </span>
           </div>
-          <div className="gh-body">
-            <div className="gh-graph" data-gh-graph aria-hidden="true" ref={graphRef}></div>
-            <div className="gh-graph-meta">
-              <span>contribution graph · last year</span>
-              <span className="scale">
-                less
-                <span className="gh-cell"></span>
-                <span className="gh-cell l1"></span>
-                <span className="gh-cell l2"></span>
-                <span className="gh-cell l3"></span>
-                <span className="gh-cell l4"></span>
-                more
-              </span>
+        </div>
+        <div className="gh-body">
+          <div className="gh-graph">
+            {GRAPH.map((lvl, i) => (
+              <div
+                key={i}
+                className={'gh-cell' + (lvl > 0 ? ' l' + lvl : '')}
+                title={lvl + ' contributions'}
+              ></div>
+            ))}
+          </div>
+          <div className="gh-graph-meta">
+            <span>1,284 contributions in the last year</span>
+            <div className="scale">
+              less
+              <span className="gh-cell"></span>
+              <span className="gh-cell l1"></span>
+              <span className="gh-cell l2"></span>
+              <span className="gh-cell l3"></span>
+              <span className="gh-cell l4"></span>
+              more
             </div>
-
-            <div className="gh-repos">
-              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+          </div>
+          <div className="gh-repos">
+            {REPOS.map((r) => (
+              <a
+                className="gh-repo"
+                key={r.name}
+                href="https://github.com/raj-khan"
+                target="_blank"
+                rel="noopener"
+              >
                 <div className="gh-repo-name">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
-                  aiagentflow
-                  <span className="pub">Public</span>
+                  <Icon.folder />
+                  <span>{r.name}</span>
+                  <span className="pub">public</span>
                 </div>
-                <p className="gh-repo-desc">Local-first CLI workflow for orchestrating coding agents on real repos.</p>
+                <div className="gh-repo-desc">{r.desc}</div>
                 <div className="gh-repo-meta">
-                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
-                  <span><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg> agentic</span>
-                  <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="9"/></svg> CLI</span>
+                  <span>
+                    <span className="lang-dot" style={{ background: r.langColor }}></span>
+                    {r.lang}
+                  </span>
+                  <span>
+                    <Icon.star /> {r.stars}
+                  </span>
+                  <span>
+                    <Icon.fork /> {r.forks}
+                  </span>
                 </div>
               </a>
-              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
-                <div className="gh-repo-name">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
-                  e2spec
-                  <span className="pub">Public</span>
-                </div>
-                <p className="gh-repo-desc">Idea → spec pipeline that produces developer-ready tickets and PRDs.</p>
-                <div className="gh-repo-meta">
-                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
-                  <span>founder-tool</span>
-                  <span>LLM</span>
-                </div>
-              </a>
-              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
-                <div className="gh-repo-name">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
-                  SEORanksLab
-                  <span className="pub">Public</span>
-                </div>
-                <p className="gh-repo-desc">GSC-based platform turning search data into SEO action workflows.</p>
-                <div className="gh-repo-meta">
-                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
-                  <span>Next.js</span>
-                  <span>NestJS</span>
-                </div>
-              </a>
-              <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
-                <div className="gh-repo-name">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
-                  quick-memorial
-                  <span className="pub">Public</span>
-                </div>
-                <p className="gh-repo-desc">Tiny SaaS for QR-shareable memorial pages — small surface, high care.</p>
-                <div className="gh-repo-meta">
-                  <span><span className="lang-dot" style={{ background: '#3178c6' }}></span>TypeScript</span>
-                  <span>Next.js</span>
-                  <span>S3</span>
-                </div>
-              </a>
-            </div>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { Icon } from '@/components/Icons'
 
 export function Header() {
   const [scrolled, setScrolled] = useState(false)
@@ -20,8 +21,8 @@ export function Header() {
         window.dispatchEvent(new CustomEvent('open-command-palette'))
       }
     }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
   }, [])
 
   const openPalette = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -30,43 +31,30 @@ export function Header() {
   }
 
   return (
-    <header className={`nav${scrolled ? ' scrolled' : ''}`} role="banner">
-      <div className="container-x nav-inner">
-        <a className="nav-brand" href="#top" aria-label="Home">
+    <header className={'nav ' + (scrolled ? 'scrolled' : '')}>
+      <div className="container nav-inner">
+        <a href="#top" className="nav-brand">
           <span className="prompt">~/</span>
-          <span>meher</span>
-          <span className="cursor" aria-hidden="true"></span>
+          <span>meherullah</span>
+          <span className="cursor"></span>
         </a>
-        <nav className="nav-links" aria-label="Primary">
+        <nav className="nav-links">
+          <a href="#work">work</a>
           <a href="#process">process</a>
           <a href="#projects">projects</a>
-          <a href="#experience">experience</a>
           <a href="#skills">skills</a>
-          <a href="#github">open-source</a>
+          <a href="#github">github</a>
           <a href="#contact">contact</a>
         </nav>
         <button
           type="button"
           className="nav-search"
-          aria-label="Open command palette"
           onClick={openPalette}
+          aria-label="Open command palette"
         >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.8"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            width="14"
-            height="14"
-            aria-hidden="true"
-          >
-            <circle cx="11" cy="11" r="7" />
-            <path d="m20 20-3.5-3.5" />
-          </svg>
-          <span className="label">Search portfolio…</span>
-          <span className="kbd">⌘K</span>
+          <Icon.search />
+          <span className="label">Search or jump to…</span>
+          <span className="kbd">⌘ K</span>
         </button>
       </div>
     </header>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,260 +1,196 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
+import { Icon } from '@/components/Icons'
 
-type TerminalLine = { delay: number; html: string }
+type TermLine =
+  | { kind: 'cmd'; text: string }
+  | { kind: 'blank' }
+  | { kind: 'kv'; k: string; v: string; color: string }
+  | { kind: 'arrow'; text: string }
+  | { kind: 'ok'; text: string }
+  | { kind: 'comment'; text: string }
 
-const TERMINAL_LINES: TerminalLine[] = [
-  { delay: 200, html: '<span class="line"><span class="prompt">$</span> <span class="cmd">npx meherullah --profile</span></span>' },
-  { delay: 400, html: '<span class="line comment"># Resolving developer identity…</span>' },
-  { delay: 350, html: '<span class="line"><span class="key">role</span><span class="arrow">:</span> <span class="val-accent">AI-Augmented Full-Stack Engineer</span></span>' },
-  { delay: 250, html: '<span class="line"><span class="key">experience</span><span class="arrow">:</span> <span class="val">8+ years</span></span>' },
-  { delay: 250, html: '<span class="line"><span class="key">focus</span><span class="arrow">:</span> <span class="val">TypeScript, Node.js, React, AWS, Agentic AI</span></span>' },
-  { delay: 250, html: '<span class="line"><span class="key">location</span><span class="arrow">:</span> <span class="val">Kuala Lumpur, Malaysia</span></span>' },
-  { delay: 250, html: '<span class="line"><span class="key">status</span><span class="arrow">:</span> <span class="val-green">building production systems + AI workflows</span></span>' },
-  { delay: 400, html: '<span class="line"></span>' },
-  { delay: 300, html: '<span class="line"><span class="prompt">$</span> <span class="cmd">founder build --with meher</span></span>' },
-  { delay: 350, html: '<span class="line"><span class="key">idea</span><span class="arrow">→</span> <span class="val">rough product concept</span></span>' },
-  { delay: 250, html: '<span class="line"><span class="key">spec</span><span class="arrow">→</span> <span class="val">developer-ready tasks</span></span>' },
-  { delay: 250, html: '<span class="line"><span class="key">stack</span><span class="arrow">→</span> <span class="val">Next.js · NestJS · PostgreSQL · AWS</span></span>' },
-  { delay: 250, html: '<span class="line"><span class="key">workflow</span><span class="arrow">→</span> <span class="val">architect → build → review → test → ship</span></span>' },
-  { delay: 300, html: '<span class="line"><span class="ok">✓ production-ready</span></span>' },
+const TERM_SCRIPT: TermLine[] = [
+  { kind: 'cmd', text: 'founder build --with meher' },
+  { kind: 'blank' },
+  { kind: 'kv', k: 'idea', v: 'rough product concept', color: '' },
+  { kind: 'arrow', text: 'running discovery...' },
+  { kind: 'kv', k: 'spec', v: 'developer-ready scope + tasks', color: 'accent' },
+  { kind: 'kv', k: 'stack', v: 'Next.js · NestJS · PostgreSQL · AWS', color: '' },
+  { kind: 'kv', k: 'workflow', v: 'architect → build → review → ship', color: '' },
+  { kind: 'kv', k: 'leverage', v: 'AI agents + CLI automation', color: 'accent' },
+  { kind: 'kv', k: 'judgment', v: 'senior engineer (human-owned)', color: 'amber' },
+  { kind: 'blank' },
+  { kind: 'ok', text: '✓ ready to ship — production hardened' },
+  { kind: 'blank' },
+  { kind: 'comment', text: '# 8+ years · KL, Malaysia · open for Q3 2026' },
 ]
 
-export function Hero() {
-  const termBodyRef = useRef<HTMLDivElement | null>(null)
-  const rootRef = useRef<HTMLElement | null>(null)
+function TerminalCard() {
+  const [step, setStep] = useState(0)
+  const [typed, setTyped] = useState('')
+  const [cycle, setCycle] = useState(0)
 
-  // Reveal observer
   useEffect(() => {
-    const root = rootRef.current
-    if (!root) return
-    const els = root.querySelectorAll<HTMLDivElement>('.reveal')
-    if (!('IntersectionObserver' in window) || !els.length) {
-      els.forEach((el) => el.classList.add('in'))
-      return
-    }
-    const io = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          if (e.isIntersecting) {
-            e.target.classList.add('in')
-            io.unobserve(e.target)
-          }
-        })
-      },
-      { threshold: 0.12, rootMargin: '0px 0px -40px 0px' },
-    )
-    els.forEach((el) => io.observe(el))
-    return () => io.disconnect()
-  }, [])
-
-  // Terminal animation
-  useEffect(() => {
-    const body = termBodyRef.current
-    if (!body) return
-    body.innerHTML = ''
     let cancelled = false
-    let i = 0
     const timeouts: ReturnType<typeof setTimeout>[] = []
-    const tick = () => {
-      if (cancelled) return
-      if (i >= TERMINAL_LINES.length) {
-        body.insertAdjacentHTML(
-          'beforeend',
-          '<span class="line"><span class="prompt">$</span> <span class="term-cursor"></span></span>',
-        )
-        return
+
+    async function run() {
+      const first = TERM_SCRIPT[0]
+      if (first.kind !== 'cmd') return
+      const cmd = first.text
+      for (let i = 0; i <= cmd.length; i++) {
+        if (cancelled) return
+        setTyped(cmd.slice(0, i))
+        await new Promise<void>((r) => {
+          const t = setTimeout(r, 40)
+          timeouts.push(t)
+        })
       }
-      const ln = TERMINAL_LINES[i++]
-      const t = setTimeout(() => {
-        if (cancelled || !termBodyRef.current) return
-        body.insertAdjacentHTML('beforeend', ln.html)
-        body.scrollTop = body.scrollHeight
-        tick()
-      }, ln.delay)
-      timeouts.push(t)
+      await new Promise<void>((r) => {
+        const t = setTimeout(r, 400)
+        timeouts.push(t)
+      })
+      for (let s = 1; s < TERM_SCRIPT.length; s++) {
+        if (cancelled) return
+        setStep(s)
+        const delay = TERM_SCRIPT[s].kind === 'blank' ? 60 : 180
+        await new Promise<void>((r) => {
+          const t = setTimeout(r, delay)
+          timeouts.push(t)
+        })
+      }
+      await new Promise<void>((r) => {
+        const t = setTimeout(r, 4000)
+        timeouts.push(t)
+      })
+      if (cancelled) return
+      setStep(0)
+      setTyped('')
+      setCycle((c) => c + 1)
     }
-    tick()
+
+    run()
     return () => {
       cancelled = true
       timeouts.forEach(clearTimeout)
     }
-  }, [])
+  }, [cycle])
+
+  const firstLine = TERM_SCRIPT[0]
+  const cmdComplete = firstLine.kind === 'cmd' && typed.length === firstLine.text.length
 
   return (
-    <section className="hero" ref={rootRef}>
-      <div className="container-x hero-grid">
-        <div className="reveal">
+    <div className="term">
+      <div className="term-bar">
+        <span className="term-dot r"></span>
+        <span className="term-dot y"></span>
+        <span className="term-dot g"></span>
+        <span className="term-title">~/founder-build — zsh — 80×24</span>
+      </div>
+      <div className="term-tabs">
+        <div className="term-tab active">
+          <Icon.terminal /> founder-build <span className="close">×</span>
+        </div>
+        <div className="term-tab">spec.md</div>
+        <div className="term-tab">architecture.md</div>
+      </div>
+      <div className="term-body">
+        <span className="line">
+          <span className="prompt">$ </span>
+          <span className="cmd">{typed}</span>
+          {!cmdComplete && <span className="term-cursor"></span>}
+        </span>
+        {cmdComplete &&
+          TERM_SCRIPT.slice(1).map((ln, i) => {
+            if (step < i + 1) return null
+            if (ln.kind === 'blank') return <span key={i} className="line">&nbsp;</span>
+            if (ln.kind === 'kv') {
+              const valCls =
+                ln.color === 'accent' ? 'val-accent' : ln.color === 'amber' ? 'val-amber' : 'val'
+              return (
+                <span key={i} className="line">
+                  <span className="key">{ln.k.padEnd(10, ' ')}: </span>
+                  <span className={valCls}>{ln.v}</span>
+                </span>
+              )
+            }
+            if (ln.kind === 'arrow') {
+              return (
+                <span key={i} className="line">
+                  <span className="arrow">→ </span>
+                  <span className="comment">{ln.text}</span>
+                </span>
+              )
+            }
+            if (ln.kind === 'ok') {
+              return (
+                <span key={i} className="line">
+                  <span className="ok">{ln.text}</span>
+                </span>
+              )
+            }
+            if (ln.kind === 'comment') {
+              return (
+                <span key={i} className="line">
+                  <span className="comment">{ln.text}</span>
+                </span>
+              )
+            }
+            return null
+          })}
+        {cmdComplete && step >= TERM_SCRIPT.length - 1 && (
+          <span className="line">
+            <span className="prompt">$ </span>
+            <span className="term-cursor"></span>
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function Hero() {
+  return (
+    <section className="hero container" id="top">
+      <div className="hero-grid">
+        <div className="hero-copy">
           <div className="hero-eyebrow">
-            <span className="pulse" aria-hidden="true"></span>
-            <span>Available for founder &amp; team engagements</span>
+            <span className="pulse"></span>
+            <span>Senior engineer · Founder-friendly · KL, MY</span>
           </div>
           <h1>
-            I help founders turn <span className="ul">ideas</span> into{' '}
-            <span className="accent">production-ready</span> software.
+            I help founders turn <span className="accent">rough ideas</span> into{' '}
+            <span className="ul">production-ready software.</span>
           </h1>
           <p className="hero-sub">
-            <strong>Meher Ullah Khan Raj</strong> — 8+ years building full-stack web systems.
-            From rough idea to architecture, implementation, and launch — with AI-assisted
-            workflows that actually ship.
+            <strong>8+ years</strong> shipping scalable web apps, SaaS products, and AI workflows.
+            I work end-to-end — from spec and architecture to backend, frontend, and deployment —
+            so you can go from idea to launch with one technical partner.
           </p>
           <div className="hero-cta">
             <a className="btn btn-primary" href="#contact">
-              Work with me
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M5 12h14" />
-                <path d="m12 5 7 7-7 7" />
-              </svg>
+              Work with me <Icon.arrowRight />
             </a>
             <a className="btn btn-ghost" href="#projects">
               View projects
             </a>
-            <a
-              className="btn btn-ghost"
-              href="/Meher Ullah - Full-Stack Software Engineer.pdf"
-              target="_blank"
-              rel="noopener"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                <polyline points="7 10 12 15 17 10" />
-                <line x1="12" y1="15" x2="12" y2="3" />
-              </svg>
-              Download CV
+            <a className="btn btn-link" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+              <Icon.github /> GitHub
             </a>
-            <a
-              className="btn btn-link"
-              href="https://github.com/raj-khan"
-              target="_blank"
-              rel="noopener"
-            >
-              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-              </svg>
-              GitHub
+            <a className="btn btn-link" href="/Meher Ullah - Full-Stack Software Engineer.pdf" target="_blank" rel="noopener">
+              <Icon.download /> CV
             </a>
           </div>
           <div className="hero-meta">
-            <div className="hero-meta-item">
-              <span className="ico" aria-hidden="true">
-                <svg
-                  viewBox="0 0 24 24"
-                  width="14"
-                  height="14"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                  <circle cx="12" cy="10" r="3" />
-                </svg>
-              </span>
-              Kuala Lumpur, Malaysia
-            </div>
-            <div className="hero-meta-item">
-              <span className="ico" aria-hidden="true">
-                <svg
-                  viewBox="0 0 24 24"
-                  width="14"
-                  height="14"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-                </svg>
-              </span>
-              8+ years shipping production systems
-            </div>
-            <div className="hero-meta-item">
-              <span className="ico" aria-hidden="true">
-                <svg
-                  viewBox="0 0 24 24"
-                  width="14"
-                  height="14"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <rect x="3" y="4" width="18" height="14" rx="2" />
-                  <path d="m7 9 3 3-3 3" />
-                  <path d="M13 15h4" />
-                </svg>
-              </span>
-              Full-stack · AWS · Agentic AI
-            </div>
+            <span className="hero-meta-item"><span className="ico">●</span> Kuala Lumpur, MY · GMT+8</span>
+            <span className="hero-meta-item"><span className="ico">●</span> Snappymob, prev. enterprise SaaS</span>
+            <span className="hero-meta-item"><span className="ico">●</span> 8+ years</span>
           </div>
         </div>
-
-        <div className="reveal">
-          <div className="term" role="img" aria-label="Terminal showing Meher's profile output">
-            <div className="term-bar" aria-hidden="true">
-              <span className="term-dot r"></span>
-              <span className="term-dot y"></span>
-              <span className="term-dot g"></span>
-              <span className="term-title">~/meherullah — zsh</span>
-            </div>
-            <div className="term-tabs" aria-hidden="true">
-              <div className="term-tab active">
-                <svg
-                  viewBox="0 0 24 24"
-                  width="11"
-                  height="11"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="4 17 10 11 4 5" />
-                  <line x1="12" y1="19" x2="20" y2="19" />
-                </svg>
-                profile
-                <span className="close">×</span>
-              </div>
-              <div className="term-tab">
-                <svg
-                  viewBox="0 0 24 24"
-                  width="11"
-                  height="11"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="4 17 10 11 4 5" />
-                  <line x1="12" y1="19" x2="20" y2="19" />
-                </svg>
-                build
-                <span className="close">×</span>
-              </div>
-            </div>
-            <div className="term-body" ref={termBodyRef}></div>
-          </div>
+        <div className="hero-term">
+          <TerminalCard />
         </div>
       </div>
     </section>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,0 +1,72 @@
+// Icon library — small SVG components used across the portfolio.
+// Direct port from /design3/meherullah-dev/project/src/icons.jsx.
+
+import * as React from 'react'
+
+type P = React.SVGProps<SVGSVGElement>
+
+const Search = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>)
+const ArrowRight = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" {...p}><path d="M5 12h14M13 5l7 7-7 7"/></svg>)
+const ArrowUpRight = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" {...p}><path d="M7 17 17 7M8 7h9v9"/></svg>)
+const Download = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...p}><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/></svg>)
+const GitHub = (p: P) => (<svg viewBox="0 0 24 24" fill="currentColor" {...p}><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.55v-2.1c-3.2.69-3.87-1.36-3.87-1.36-.53-1.33-1.29-1.69-1.29-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.37.96.1-.75.4-1.26.74-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.09-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.19 1.18a11.1 11.1 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.21-1.49 3.19-1.18 3.19-1.18.62 1.59.23 2.76.11 3.05.74.8 1.19 1.83 1.19 3.09 0 4.42-2.69 5.39-5.25 5.68.41.35.77 1.04.77 2.1v3.11c0 .3.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/></svg>)
+const Mail = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...p}><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/></svg>)
+const LinkedIn = (p: P) => (<svg viewBox="0 0 24 24" fill="currentColor" {...p}><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8.34 18H5.67V9.67h2.67V18zM7 8.5a1.55 1.55 0 1 1 0-3.1 1.55 1.55 0 0 1 0 3.1zM18.34 18h-2.67v-4.06c0-.97-.02-2.22-1.36-2.22s-1.56 1.06-1.56 2.15V18h-2.67V9.67h2.56v1.14h.04c.36-.67 1.22-1.37 2.52-1.37 2.69 0 3.19 1.77 3.19 4.07V18z"/></svg>)
+const External = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" {...p}><path d="M7 17 17 7M8 7h9v9"/></svg>)
+const Folder = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></svg>)
+const Star = (p: P) => (<svg viewBox="0 0 24 24" fill="currentColor" {...p}><path d="m12 2 3.1 6.3 6.9 1-5 4.9 1.2 6.9L12 17.8 5.8 21l1.2-6.9-5-4.9 6.9-1L12 2z"/></svg>)
+const Fork = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" {...p}><circle cx="6" cy="5" r="2"/><circle cx="6" cy="19" r="2"/><circle cx="18" cy="5" r="2"/><path d="M6 7v10M18 7v3a4 4 0 0 1-4 4h-4"/></svg>)
+const Code = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...p}><path d="m8 6-6 6 6 6M16 6l6 6-6 6M14 4l-4 16"/></svg>)
+const Cpu = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M9 1v3M15 1v3M9 20v3M15 20v3M20 9h3M20 14h3M1 9h3M1 14h3"/></svg>)
+const Cloud = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><path d="M17.5 19a4.5 4.5 0 1 0-.6-9 6 6 0 0 0-11.4 2 4 4 0 0 0 .5 8h11.5z"/></svg>)
+const Layers = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinejoin="round" {...p}><path d="M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>)
+const Sparkle = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinejoin="round" {...p}><path d="M12 3v3m0 12v3M3 12h3m12 0h3M5.6 5.6l2.1 2.1m8.6 8.6 2.1 2.1M5.6 18.4l2.1-2.1m8.6-8.6 2.1-2.1"/></svg>)
+const Shield = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinejoin="round" {...p}><path d="M12 3 4 6v6c0 5 3.5 8.5 8 9 4.5-.5 8-4 8-9V6l-8-3z"/><path d="m9 12 2 2 4-4"/></svg>)
+const Zap = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinejoin="round" {...p}><path d="M13 2 3 14h8l-1 8 10-12h-8l1-8z"/></svg>)
+const Target = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="5"/><circle cx="12" cy="12" r="1" fill="currentColor"/></svg>)
+const Git = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" {...p}><circle cx="6" cy="6" r="2"/><circle cx="18" cy="18" r="2"/><circle cx="6" cy="18" r="2"/><path d="M6 8v8M8 18h8M18 6v10"/></svg>)
+const Terminal = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...p}><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>)
+const Agent = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><rect x="5" y="7" width="14" height="12" rx="2"/><path d="M12 7V3M8 3h8M9 12h.01M15 12h.01M9 16h6"/></svg>)
+const Builder = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...p}><path d="M14.7 6.3a4 4 0 0 1 5 5L14 17l-3 1 1-3 5.6-5.6a1 1 0 0 0-1.4-1.4L10.6 13.6"/><path d="M4 21h6M4 17l4-4"/></svg>)
+const Reviewer = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5M8 11h6M11 8v6"/></svg>)
+const Tester = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" {...p}><path d="M9 3v6l-5 9a2 2 0 0 0 2 3h12a2 2 0 0 0 2-3l-5-9V3M9 3h6M9 13h6"/></svg>)
+const Human = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>)
+const Rocket = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinejoin="round" {...p}><path d="M14 5c2 5 0 11-4 14l-3-3c3-4 9-6 14-4-2 2-4 4-7 5l-3-3z"/><path d="M9 12 5 8c-1 2 0 5 3 7zM12 15c2 3 5 4 7 3l-4-4"/></svg>)
+const Flow = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" {...p}><circle cx="4" cy="12" r="2"/><circle cx="20" cy="6" r="2"/><circle cx="20" cy="18" r="2"/><path d="M6 12h12M6 12c4 0 8-6 12-6M6 12c4 0 8 6 12 6"/></svg>)
+const Send = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...p}><path d="m22 2-7 20-4-9-9-4 20-7zM22 2 11 13"/></svg>)
+const FileX = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>)
+const Book = (p: P) => (<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...p}><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14zM20 17v4H6.5"/></svg>)
+
+export const Icon = {
+  search: Search,
+  arrowRight: ArrowRight,
+  arrowUpRight: ArrowUpRight,
+  download: Download,
+  github: GitHub,
+  mail: Mail,
+  linkedin: LinkedIn,
+  external: External,
+  folder: Folder,
+  star: Star,
+  fork: Fork,
+  code: Code,
+  cpu: Cpu,
+  cloud: Cloud,
+  layers: Layers,
+  sparkle: Sparkle,
+  shield: Shield,
+  zap: Zap,
+  target: Target,
+  git: Git,
+  terminal: Terminal,
+  agent: Agent,
+  builder: Builder,
+  reviewer: Reviewer,
+  tester: Tester,
+  human: Human,
+  rocket: Rocket,
+  flow: Flow,
+  send: Send,
+  filex: FileX,
+  book: Book,
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,316 +1,159 @@
+import { Icon } from '@/components/Icons'
+
+type ProjectLink = { label: string; icon: React.ReactNode; href: string }
+type Project = {
+  name: string
+  badge: string
+  tagline: string
+  problem: string
+  role: string
+  impact: string
+  stack: string[]
+  links: ProjectLink[]
+}
+
+const PROJECTS: Project[] = [
+  {
+    name: 'raj-khan/aiagentflow',
+    badge: 'featured',
+    tagline: 'Local-first CLI for orchestrating multi-agent software engineering workflows.',
+    problem: 'Coding agents are powerful but chaotic — no shared context, no review gates, no auditability.',
+    role: 'Creator & maintainer · architecture, CLI, agent contracts, ops',
+    impact: 'Brings agent runs into a structured pipeline with checkpoints, review, and replay — usable on real codebases.',
+    stack: ['TypeScript', 'Node.js', 'CLI', 'LLM tooling', 'git'],
+    links: [
+      { label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan' },
+      { label: 'readme', icon: <Icon.book />, href: '#' },
+    ],
+  },
+  {
+    name: 'raj-khan/e2spec',
+    badge: 'featured',
+    tagline: 'Turn rough product ideas into developer-ready specs in minutes.',
+    problem: 'Founders pitch ideas; engineers need scope. The translation layer is where most projects stall.',
+    role: 'Creator · spec generation pipeline, prompt design, output schema',
+    impact: 'Converts a 2-paragraph idea into milestones, user stories, data model sketch, and a ticket-shaped backlog.',
+    stack: ['TypeScript', 'Next.js', 'LLM', 'structured output'],
+    links: [
+      { label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan' },
+      { label: 'live', icon: <Icon.external />, href: '#' },
+    ],
+  },
+  {
+    name: 'snappymob/SEORanksLab',
+    badge: 'client',
+    tagline: 'Turn Google Search Console data into a prioritised SEO action workflow.',
+    problem: 'GSC dumps thousands of queries; teams don\'t know which 20 to act on this week.',
+    role: 'Full-stack engineer · backend pipeline, scoring engine, dashboard UI',
+    impact: 'Ranks opportunities by impact × effort, generates briefs, and tracks delta. Used by content teams weekly.',
+    stack: ['Next.js', 'NestJS', 'PostgreSQL', 'AWS', 'GSC API'],
+    links: [
+      { label: 'case study', icon: <Icon.book />, href: '#' },
+      { label: 'live', icon: <Icon.external />, href: '#' },
+    ],
+  },
+  {
+    name: 'raj-khan/quick-memorial',
+    badge: 'side',
+    tagline: 'Generate beautiful memorial pages with QR-code sharing — in under five minutes.',
+    problem: 'Families want a digital place to gather memories; existing tools are slow, ugly, or paywalled.',
+    role: 'Solo build · product, design, full-stack, hosting',
+    impact: 'Free public templates, QR cards for graveside scanning, contributor messages without account creation.',
+    stack: ['Next.js', 'Tailwind', 'PostgreSQL', 'S3', 'QR'],
+    links: [{ label: 'live', icon: <Icon.external />, href: '#' }],
+  },
+  {
+    name: 'private/enterprise-systems',
+    badge: 'production',
+    tagline: 'Financial, HRM, and internal tools across multiple enterprise clients.',
+    problem: 'Enterprise teams stuck on legacy back-offices need modern web apps without ripping everything out.',
+    role: 'Full-stack lead · architecture, frontend, NestJS APIs, AWS, CI/CD, handoff',
+    impact: 'Shipped finance dashboards, HRM workflows, and internal admin tools running in production with real users.',
+    stack: ['React', 'NestJS', 'PostgreSQL', 'AWS ECS', 'Docker'],
+    links: [{ label: 'summary', icon: <Icon.book />, href: '#' }],
+  },
+  {
+    name: 'raj-khan/lab',
+    badge: 'experiment',
+    tagline: 'Public experiments — CLI scaffolds, agent recipes, dev-workflow probes.',
+    problem: 'Most AI-assisted patterns only show up after you\'ve shipped a few. So I keep shipping them.',
+    role: 'Hacking in public · weekly-ish',
+    impact: 'Small, opinionated repos that map directly to things I use in client work.',
+    stack: ['TypeScript', 'CLI', 'Claude', 'agentic'],
+    links: [{ label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan' }],
+  },
+]
+
 export function Projects() {
-	return (
-		<section className="section" id="projects">
-			<div className="container-x">
-				<div className="section-head reveal">
-					<div>
-						<div className="section-eyebrow">
-							<span className="dot"></span>
-							<span className="num">05</span>
-							<span>build artifacts</span>
-						</div>
-						<h2 className="section-title">
-							Selected work &amp; <em>open-source builds.</em>
-						</h2>
-					</div>
-					<p className="section-sub">
-						A mix of public projects and production systems I&apos;ve owned —
-						each one is proof, not portfolio filler.
-					</p>
-				</div>
-
-				<div className="projects-grid reveal">
-					<article className="project">
-						<header className="project-head">
-							<div className="project-folder">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
-								</svg>
-							</div>
-							<div className="project-title-row">
-								<div className="project-title">
-									<span className="slash">raj-khan /</span>
-									<span>aiagentflow</span>
-									<span className="badge">FEATURED</span>
-								</div>
-								<div className="project-tagline">
-									Local-first CLI workflow for agentic software engineering.
-								</div>
-							</div>
-						</header>
-						<div className="project-body">
-							<div className="project-row">
-								<span className="k">Problem</span>
-								<span className="v">
-									Most agentic tooling is cloud-locked, opaque, and hard to
-									wire into a real engineering workflow.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Built</span>
-								<span className="v">
-									<strong>A local-first orchestrator</strong> that runs
-									multiple coding agents against a real repo, with review
-									&amp; checkpointing in the loop.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Why</span>
-								<span className="v">
-									Engineers should own their agents — not the other way
-									around.
-								</span>
-							</div>
-						</div>
-						<footer className="project-foot">
-							<div className="project-stack">
-								<span>TypeScript</span>
-								<span>Node.js</span>
-								<span>CLI</span>
-								<span>LLM</span>
-							</div>
-							<div className="project-links">
-								<a
-									href="https://github.com/raj-khan"
-									target="_blank"
-									rel="noopener"
-									aria-label="View on GitHub"
-								>
-									<svg viewBox="0 0 24 24" fill="currentColor">
-										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-									</svg>
-									<span>GitHub</span>
-								</a>
-							</div>
-						</footer>
-					</article>
-
-					<article className="project">
-						<header className="project-head">
-							<div className="project-folder">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-									<polyline points="14 2 14 8 20 8" />
-								</svg>
-							</div>
-							<div className="project-title-row">
-								<div className="project-title">
-									<span className="slash">raj-khan /</span>
-									<span>e2spec</span>
-									<span className="badge">FOUNDER TOOL</span>
-								</div>
-								<div className="project-tagline">
-									Turns rough ideas into developer-ready specifications.
-								</div>
-							</div>
-						</header>
-						<div className="project-body">
-							<div className="project-row">
-								<span className="k">Problem</span>
-								<span className="v">
-									Founders pitch ideas; engineers need tickets. The gap
-									costs weeks.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Built</span>
-								<span className="v">
-									<strong>A guided pipeline</strong> that converts vague
-									product ideas into structured PRDs, user stories, and
-									task breakdowns.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Why</span>
-								<span className="v">
-									Clear specs are the cheapest leverage in software
-									delivery.
-								</span>
-							</div>
-						</div>
-						<footer className="project-foot">
-							<div className="project-stack">
-								<span>Next.js</span>
-								<span>TypeScript</span>
-								<span>LLM</span>
-								<span>Postgres</span>
-							</div>
-							<div className="project-links">
-								<a
-									href="https://github.com/raj-khan"
-									target="_blank"
-									rel="noopener"
-								>
-									<svg viewBox="0 0 24 24" fill="currentColor">
-										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-									</svg>
-									<span>GitHub</span>
-								</a>
-							</div>
-						</footer>
-					</article>
-
-					<article className="project">
-						<header className="project-head">
-							<div className="project-folder">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<path d="M3 3h18v18H3z" />
-									<path d="M3 9h18" />
-									<path d="M9 21V9" />
-								</svg>
-							</div>
-							<div className="project-title-row">
-								<div className="project-title">
-									<span className="slash">raj-khan /</span>
-									<span>SEORanksLab</span>
-									<span className="badge">PRODUCT</span>
-								</div>
-								<div className="project-tagline">
-									GSC data → SEO action workflows.
-								</div>
-							</div>
-						</header>
-						<div className="project-body">
-							<div className="project-row">
-								<span className="k">Problem</span>
-								<span className="v">
-									Search Console gives data; teams need decisions and
-									actions.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Built</span>
-								<span className="v">
-									<strong>An SEO action platform</strong> that ingests GSC,
-									prioritizes opportunities, and tracks the work to ship
-									them.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Why</span>
-								<span className="v">
-									Insights without workflows are wallpaper.
-								</span>
-							</div>
-						</div>
-						<footer className="project-foot">
-							<div className="project-stack">
-								<span>Next.js</span>
-								<span>NestJS</span>
-								<span>Postgres</span>
-								<span>AWS</span>
-							</div>
-							<div className="project-links">
-								<a
-									href="https://github.com/raj-khan"
-									target="_blank"
-									rel="noopener"
-								>
-									<svg viewBox="0 0 24 24" fill="currentColor">
-										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-									</svg>
-									<span>GitHub</span>
-								</a>
-							</div>
-						</footer>
-					</article>
-
-					<article className="project">
-						<header className="project-head">
-							<div className="project-folder">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<rect x="3" y="3" width="18" height="18" rx="2" />
-									<path d="M3 9h18" />
-									<path d="m9 14 2 2 4-4" />
-								</svg>
-							</div>
-							<div className="project-title-row">
-								<div className="project-title">
-									<span className="slash">raj-khan /</span>
-									<span>quick-memorial</span>
-									<span className="badge">SHIPPED</span>
-								</div>
-								<div className="project-tagline">
-									Memorial page generator with QR sharing.
-								</div>
-							</div>
-						</header>
-						<div className="project-body">
-							<div className="project-row">
-								<span className="k">Problem</span>
-								<span className="v">
-									Families need a respectful, low-friction way to remember
-									loved ones together.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Built</span>
-								<span className="v">
-									<strong>A small SaaS</strong> that creates shareable
-									memorial pages with QR codes and quiet, accessible
-									design.
-								</span>
-							</div>
-							<div className="project-row">
-								<span className="k">Why</span>
-								<span className="v">Soft tech for hard moments.</span>
-							</div>
-						</div>
-						<footer className="project-foot">
-							<div className="project-stack">
-								<span>Next.js</span>
-								<span>TypeScript</span>
-								<span>S3</span>
-								<span>QR</span>
-							</div>
-							<div className="project-links">
-								<a
-									href="https://github.com/raj-khan"
-									target="_blank"
-									rel="noopener"
-								>
-									<svg viewBox="0 0 24 24" fill="currentColor">
-										<path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55v-2.1c-3.2.7-3.87-1.36-3.87-1.36-.52-1.31-1.28-1.66-1.28-1.66-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.76 2.7 1.25 3.36.96.1-.75.4-1.25.73-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.05 11.05 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z" />
-									</svg>
-									<span>GitHub</span>
-								</a>
-							</div>
-						</footer>
-					</article>
-				</div>
-			</div>
-		</section>
-	);
+  return (
+    <section className="section container reveal" id="projects">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">05 /</span> <span className="dot"></span>{' '}
+            <span>build artifacts</span>
+          </div>
+          <h2 className="section-title">
+            Selected work — <em>proof, not portfolio.</em>
+          </h2>
+        </div>
+        <p className="section-sub">
+          Six representative builds across products, client work, and open-source. Each one shipped
+          to real users.
+        </p>
+      </div>
+      <div className="projects-grid">
+        {PROJECTS.map((p, i) => (
+          <article className="project" key={i}>
+            <div className="project-head">
+              <div className="project-folder">
+                <Icon.folder />
+              </div>
+              <div className="project-title-row">
+                <div className="project-title">
+                  <span className="slash">{p.name.split('/')[0]}/</span>
+                  <span>{p.name.split('/')[1]}</span>
+                  <span className="badge">{p.badge}</span>
+                </div>
+                <div className="project-tagline">{p.tagline}</div>
+              </div>
+            </div>
+            <div className="project-body">
+              <div className="project-row">
+                <span className="k">problem</span>
+                <span className="v">{p.problem}</span>
+              </div>
+              <div className="project-row">
+                <span className="k">role</span>
+                <span className="v">{p.role}</span>
+              </div>
+              <div className="project-row">
+                <span className="k">impact</span>
+                <span className="v">{p.impact}</span>
+              </div>
+            </div>
+            <div className="project-foot">
+              <div className="project-stack">
+                {p.stack.map((s) => (
+                  <span key={s}>{s}</span>
+                ))}
+              </div>
+              <div className="project-links">
+                {p.links.map((l, j) => (
+                  <a
+                    key={j}
+                    href={l.href}
+                    target={l.href.startsWith('http') ? '_blank' : undefined}
+                    rel="noopener"
+                  >
+                    {l.icon} {l.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
 }

--- a/src/components/RevealObserver.tsx
+++ b/src/components/RevealObserver.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function RevealObserver() {
+  useEffect(() => {
+    const els = document.querySelectorAll<HTMLElement>('.reveal')
+    if (!els.length) return
+
+    if (!('IntersectionObserver' in window)) {
+      els.forEach((el) => el.classList.add('in'))
+      return
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('in')
+            io.unobserve(entry.target)
+          }
+        })
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -40px 0px' }
+    )
+
+    els.forEach((el) => io.observe(el))
+    return () => io.disconnect()
+  }, [])
+
+  return null
+}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,200 +1,41 @@
-export function Services() {
-	return (
-		<section className="section" id="services">
-			<div className="container-x">
-				<div className="section-head reveal">
-					<div>
-						<div className="section-eyebrow">
-							<span className="dot"></span>
-							<span className="num">04</span>
-							<span>how I can help</span>
-						</div>
-						<h2 className="section-title">
-							Engagements I&apos;m built for.
-						</h2>
-					</div>
-					<p className="section-sub">
-						Fractional engineering for founders &amp; teams who need a
-						senior pair of hands across the whole stack.
-					</p>
-				</div>
+import { Icon } from '@/components/Icons'
 
-				<div className="services-grid reveal">
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<path d="m12 2 3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7Z" />
-							</svg>
-						</div>
-						<h4>MVP development</h4>
-						<p>
-							From rough idea to a usable v1 — built so it can grow, not
-							just shipped to a demo.
-						</p>
-					</div>
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<rect x="3" y="3" width="18" height="18" rx="2" />
-								<path d="M9 9h6v6H9z" />
-							</svg>
-						</div>
-						<h4>SaaS product build</h4>
-						<p>
-							Auth, billing, dashboards, multi-tenancy — the boring pieces
-							every SaaS actually needs.
-						</p>
-					</div>
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<path d="M4 4h16v4H4z" />
-								<path d="M4 12h10v4H4z" />
-								<path d="M4 20h16" />
-							</svg>
-						</div>
-						<h4>Full-stack delivery</h4>
-						<p>
-							Frontend, backend, infra — one accountable owner instead of
-							five vendors.
-						</p>
-					</div>
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<ellipse cx="12" cy="5" rx="9" ry="3" />
-								<path d="M3 5v6c0 1.66 4 3 9 3s9-1.34 9-3V5" />
-								<path d="M3 11v6c0 1.66 4 3 9 3s9-1.34 9-3v-6" />
-							</svg>
-						</div>
-						<h4>Backend &amp; API architecture</h4>
-						<p>
-							NestJS, Node, Postgres — services that hold up as the
-							product gets real.
-						</p>
-					</div>
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<circle cx="12" cy="12" r="3" />
-								<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" />
-							</svg>
-						</div>
-						<h4>AI workflow integration</h4>
-						<p>
-							Drop agents into real workflows — with review, tests, and
-							guardrails.
-						</p>
-					</div>
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<rect x="2" y="4" width="20" height="16" rx="2" />
-								<polyline points="6 10 9 13 6 16" />
-								<line x1="13" y1="16" x2="17" y2="16" />
-							</svg>
-						</div>
-						<h4>Developer tooling / CLIs</h4>
-						<p>
-							Local-first tools that make your team faster every single
-							day.
-						</p>
-					</div>
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-								<polyline points="14 2 14 8 20 8" />
-								<line x1="9" y1="13" x2="15" y2="13" />
-								<line x1="9" y1="17" x2="15" y2="17" />
-							</svg>
-						</div>
-						<h4>Technical planning</h4>
-						<p>
-							Turn rough ideas into specs, estimates, and a path your team
-							can actually run.
-						</p>
-					</div>
-					<div className="service">
-						<div className="service-ico">
-							<svg
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<path d="M9 12h6" />
-								<path d="M12 9v6" />
-								<circle cx="12" cy="12" r="9" />
-							</svg>
-						</div>
-						<h4>Production debugging</h4>
-						<p>
-							Performance regressions, outages, mystery bugs — diagnosed
-							and put to bed.
-						</p>
-					</div>
-				</div>
-			</div>
-		</section>
-	);
+const SERVICES = [
+  { ico: <Icon.zap />, name: 'MVP development', desc: 'Idea → working product. 4–10 week sprints with weekly demos and a real launch at the end.' },
+  { ico: <Icon.layers />, name: 'SaaS product build', desc: 'Multi-tenant, billing, auth, dashboards. The non-glamorous backbone that paid SaaS needs.' },
+  { ico: <Icon.code />, name: 'Full-stack feature delivery', desc: 'Drop into an existing team and ship vertical slices — frontend, API, data, deploy.' },
+  { ico: <Icon.cpu />, name: 'Backend & API architecture', desc: 'Data model, contracts, jobs, queues. Designed to scale before scale is a problem.' },
+  { ico: <Icon.sparkle />, name: 'AI workflow integration', desc: 'Agents, RAG, CLI automation, prompt pipelines — integrated into your real codebase, not a demo.' },
+  { ico: <Icon.terminal />, name: 'Developer tooling & CLIs', desc: 'Internal tools, scripts, CLIs that make your team faster every week, not just once.' },
+  { ico: <Icon.target />, name: 'Technical planning', desc: 'Turning rough product ideas into engineering scope, milestones, and honest estimates.' },
+  { ico: <Icon.shield />, name: 'Production debugging', desc: 'Things on fire? I read logs, fix the root cause, and write the runbook so it doesn\'t repeat.' },
+]
+
+export function Services() {
+  return (
+    <section className="section container reveal">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">04 /</span> <span className="dot"></span>{' '}
+            <span>how i can help</span>
+          </div>
+          <h2 className="section-title">Eight ways founders &amp; teams hire me.</h2>
+        </div>
+        <p className="section-sub">
+          Most engagements blend a few of these. Some are 4-week projects, some are 6-month
+          embedded partnerships.
+        </p>
+      </div>
+      <div className="services-grid">
+        {SERVICES.map((s, i) => (
+          <div className="service" key={i}>
+            <div className="service-ico">{s.ico}</div>
+            <h4>{s.name}</h4>
+            <p>{s.desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
 }

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,190 +1,44 @@
-export function Skills() {
-	return (
-		<section className="section" id="skills">
-			<div className="container-x">
-				<div className="section-head reveal">
-					<div>
-						<div className="section-eyebrow">
-							<span className="dot"></span>
-							<span className="num">07</span>
-							<span>capabilities</span>
-						</div>
-						<h2 className="section-title">
-							Tools I reach for, <em>grouped by what they do.</em>
-						</h2>
-					</div>
-					<p className="section-sub">
-						No fake percentage bars — just the actual stack I use to ship
-						production software.
-					</p>
-				</div>
+import { Icon } from '@/components/Icons'
 
-				<div className="skills-grid reveal">
-					<div className="skill-card">
-						<div className="skill-head">
-							<span className="ico">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<rect x="3" y="3" width="18" height="18" rx="2" />
-									<path d="M3 9h18" />
-								</svg>
-							</span>
-							<strong>Product Engineering</strong>
-						</div>
-						<div className="skill-list">
-							<span>MVPs</span>
-							<span>SaaS</span>
-							<span>Dashboards</span>
-							<span>Internal tools</span>
-							<span>Multi-tenant</span>
-						</div>
-					</div>
-					<div className="skill-card">
-						<div className="skill-head">
-							<span className="ico">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<polyline points="4 17 10 11 4 5" />
-									<line x1="12" y1="19" x2="20" y2="19" />
-								</svg>
-							</span>
-							<strong>Frontend</strong>
-						</div>
-						<div className="skill-list">
-							<span>React</span>
-							<span>Next.js</span>
-							<span>TypeScript</span>
-							<span>Tailwind</span>
-							<span>Vite</span>
-						</div>
-					</div>
-					<div className="skill-card">
-						<div className="skill-head">
-							<span className="ico">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<ellipse cx="12" cy="5" rx="9" ry="3" />
-									<path d="M3 5v6c0 1.66 4 3 9 3s9-1.34 9-3V5" />
-									<path d="M3 11v6c0 1.66 4 3 9 3s9-1.34 9-3v-6" />
-								</svg>
-							</span>
-							<strong>Backend</strong>
-						</div>
-						<div className="skill-list">
-							<span>Node.js</span>
-							<span>NestJS</span>
-							<span>REST</span>
-							<span>GraphQL</span>
-							<span>PostgreSQL</span>
-							<span>MySQL</span>
-						</div>
-					</div>
-					<div className="skill-card">
-						<div className="skill-head">
-							<span className="ico">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<path d="M20 16.58A5 5 0 0 0 18 7h-1.26A8 8 0 1 0 4 15.25" />
-									<polyline points="8 19 12 23 16 19" />
-									<line x1="12" y1="13" x2="12" y2="23" />
-								</svg>
-							</span>
-							<strong>Cloud &amp; DevOps</strong>
-						</div>
-						<div className="skill-list">
-							<span>AWS</span>
-							<span>EC2</span>
-							<span>S3</span>
-							<span>RDS</span>
-							<span>Docker</span>
-							<span>GitHub Actions</span>
-							<span>CI/CD</span>
-						</div>
-					</div>
-					<div className="skill-card">
-						<div className="skill-head">
-							<span className="ico">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<path d="m21 16-9 5-9-5" />
-									<path d="m21 12-9 5-9-5" />
-									<path d="m12 2 9 5-9 5-9-5 9-5Z" />
-								</svg>
-							</span>
-							<strong>AI Workflow</strong>
-						</div>
-						<div className="skill-list">
-							<span>Claude</span>
-							<span>Cursor</span>
-							<span>Copilot</span>
-							<span>Agent workflows</span>
-							<span>Prompt engineering</span>
-							<span>CLI automation</span>
-						</div>
-					</div>
-					<div className="skill-card">
-						<div className="skill-head">
-							<span className="ico">
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									aria-hidden="true"
-								>
-									<circle cx="12" cy="12" r="9" />
-									<path d="m9 12 2 2 4-4" />
-								</svg>
-							</span>
-							<strong>Quality &amp; Delivery</strong>
-						</div>
-						<div className="skill-list">
-							<span>Testing</span>
-							<span>Code review</span>
-							<span>Architecture</span>
-							<span>Observability</span>
-							<span>Monitoring</span>
-						</div>
-					</div>
-				</div>
-			</div>
-		</section>
-	);
+const SKILL_GROUPS = [
+  { ico: <Icon.target />, name: 'Product Engineering', items: ['MVPs', 'SaaS', 'Dashboards', 'Internal tools', 'Spec → ship'] },
+  { ico: <Icon.layers />, name: 'Frontend', items: ['React', 'Next.js', 'TypeScript', 'Tailwind', 'Design systems'] },
+  { ico: <Icon.cpu />, name: 'Backend', items: ['Node.js', 'NestJS', 'REST', 'GraphQL', 'PostgreSQL', 'Queues'] },
+  { ico: <Icon.cloud />, name: 'Cloud & DevOps', items: ['AWS ECS', 'S3', 'Docker', 'GitHub Actions', 'CI/CD', 'Observability'] },
+  { ico: <Icon.sparkle />, name: 'AI Workflow', items: ['Claude', 'Cursor', 'Agentic CLI', 'Prompt design', 'Eval loops'] },
+  { ico: <Icon.shield />, name: 'Quality', items: ['Code review', 'Testing', 'Architecture', 'Maintainability', 'Security basics'] },
+]
+
+export function Skills() {
+  return (
+    <section className="section container reveal" id="skills">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">07 /</span> <span className="dot"></span>{' '}
+            <span>capabilities</span>
+          </div>
+          <h2 className="section-title">What I bring to the build.</h2>
+        </div>
+        <p className="section-sub">
+          No percentage bars. Just tools I actually use to ship every week.
+        </p>
+      </div>
+      <div className="skills-grid">
+        {SKILL_GROUPS.map((g, i) => (
+          <div className="skill-card" key={i}>
+            <div className="skill-head">
+              <span className="ico">{g.ico}</span>
+              <strong>{g.name}</strong>
+            </div>
+            <div className="skill-list">
+              {g.items.map((it) => (
+                <span key={it}>{it}</span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
 }

--- a/src/components/Writing.tsx
+++ b/src/components/Writing.tsx
@@ -1,0 +1,48 @@
+import { Icon } from '@/components/Icons'
+
+const POSTS = [
+  { date: 'Apr 12 · 2026', title: 'Why I let the agent write tests first', meta: ['agentic', '8 min read'] },
+  { date: 'Mar 03 · 2026', title: 'Refactoring a 4-year-old NestJS monolith without downtime', meta: ['backend', '12 min read'] },
+  { date: 'Feb 14 · 2026', title: 'Specs are the new prompts: what e2spec taught me', meta: ['ai-workflow', '6 min read'] },
+  { date: 'Jan 20 · 2026', title: 'Postgres beats your vector DB until it doesn\'t', meta: ['data', '9 min read'] },
+  { date: 'Dec 02 · 2025', title: 'A senior engineer\'s case against vibe coding', meta: ['essay', '11 min read'] },
+]
+
+export function Writing() {
+  return (
+    <section className="section container reveal">
+      <div className="section-head">
+        <div>
+          <div className="section-eyebrow">
+            <span className="num">09 /</span> <span className="dot"></span>{' '}
+            <span>engineering notes</span>
+          </div>
+          <h2 className="section-title">
+            Writing — <em>practical, not promotional.</em>
+          </h2>
+        </div>
+        <p className="section-sub">
+          Field notes from production work. Backend, frontend, devops, and what I&apos;m learning
+          about agentic engineering.
+        </p>
+      </div>
+      <div className="writing-list">
+        {POSTS.map((p, i) => (
+          <a className="writing-row" key={i} href="#">
+            <div className="date">{p.date}</div>
+            <div>
+              <div className="title">{p.title}</div>
+              <div className="meta">
+                <span className="tag">#{p.meta[0]}</span>
+                <span>{p.meta[1]}</span>
+              </div>
+            </div>
+            <div className="arrow">
+              <Icon.arrowRight />
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

- Complete rebrand with new OKLCH dark design system (lime/amber/violet tri-accent)
- Global `RevealObserver` — fixes the all-sections-black bug from the scoped observer
- All 14 page sections rewritten to match design3 JSX source
- New components: `Icons.tsx`, `RevealObserver.tsx`, `Writing.tsx`
- Hero: character-by-character TERM_SCRIPT terminal animation with cycle restart
- Projects: 6 entries (up from 4) with problem/role/impact row layout
- Experience: 5 MISSIONS + STATS grid
- GitHubDashboard: module-scope seeded RNG (SSR-safe), `Icon.*` throughout
- BuildProcess: new CI pipeline visual log layout
- Contact: new card layout with 4 channels

## Test plan

- [ ] Build passes (`npx next build` — verified ✓)
- [ ] TypeScript clean (`npx tsc --noEmit` — verified ✓)
- [ ] All sections visible (not black) after deploy
- [ ] Terminal animation cycles correctly in Hero
- [ ] Command palette opens with ⌘K / Ctrl+K
- [ ] Contribution graph renders (seeded RNG, no hydration mismatch)