### PR TITLE
Reposition: soften founder-hire framing to SE-forward builder mindset

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -12,18 +12,17 @@ export function Contact() {
     <section className="contact container reveal" id="contact">
       <div className="contact-card">
         <div className="contact-prompt">
-          <span>$ founder contact --to meher</span>
+          <span>$ engineer contact --to meher</span>
           <span
             className="term-cursor"
             style={{ display: 'inline-block', width: 7, height: 13, background: 'var(--accent)', verticalAlign: -1 }}
           ></span>
         </div>
         <h2>
-          Got an idea you want to turn into <em>real software?</em>
+          Building something interesting? <em>Let&apos;s talk.</em>
         </h2>
         <p className="contact-sub">
-          If you&apos;re a founder, startup, or team with a product idea, an AI workflow problem,
-          or a build that&apos;s stalled — let&apos;s talk. I reply within a day, in your timezone.
+          Whether it&apos;s a technical question, an interesting problem, or just a conversation about software and building things — I&apos;m always happy to connect.
         </p>
         <div className="contact-actions">
           <a className="btn btn-primary" href="mailto:meherullah97@gmail.com">

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -22,7 +22,7 @@ export function Contact() {
           Building something interesting? <em>Let&apos;s talk.</em>
         </h2>
         <p className="contact-sub">
-          Whether it&apos;s a technical question, an interesting problem, or just a conversation about software and building things — I&apos;m always happy to connect.
+          Technical question, interesting problem, or just want to talk software. Drop me a line.
         </p>
         <div className="contact-actions">
           <a className="btn btn-primary" href="mailto:meherullah97@gmail.com">

--- a/src/components/FounderProblems.tsx
+++ b/src/components/FounderProblems.tsx
@@ -8,32 +8,32 @@ type Problem = {
 
 const PROBLEMS: Problem[] = [
   {
-    issue: 'ISSUE-001',
-    state: 'open',
-    q: 'You have an idea but no technical roadmap.',
-    a: 'I turn rough product concepts into clear specs, system architecture, and an MVP plan you can actually ship — without 6 weeks of slideware.',
-    tags: ['discovery', 'specs', 'architecture'],
+    issue: ‘ISSUE-001’,
+    state: ‘open’,
+    q: ‘You have an idea but no technical roadmap.’,
+    a: ‘I turn rough product concepts into clear specs, system architecture, and an MVP plan you can actually ship. No 6-week discovery process.’,
+    tags: [‘discovery’, ‘specs’, ‘architecture’],
   },
   {
-    issue: 'ISSUE-002',
-    state: 'open',
-    q: 'Your MVP is slow, messy, or hard to extend.',
-    a: 'I refactor full-stack codebases, stabilise CI/CD, fix the data model, and bring the system back into a state where adding features is fast again.',
-    tags: ['refactor', 'stability', 'speed'],
+    issue: ‘ISSUE-002’,
+    state: ‘open’,
+    q: ‘Your MVP is slow, messy, or hard to extend.’,
+    a: ‘I refactor full-stack codebases, stabilise CI/CD, fix the data model, and get the system back to a place where adding features is fast again.’,
+    tags: [‘refactor’, ‘stability’, ‘speed’],
   },
   {
-    issue: 'ISSUE-003',
-    state: 'open',
-    q: 'You need someone who can own the whole build.',
-    a: "Frontend, backend, database, cloud, auth, deploy, monitoring — one technical partner instead of coordinating three contractors who don’t talk to each other.",
-    tags: ['full-stack', 'ownership', 'delivery'],
+    issue: ‘ISSUE-003’,
+    state: ‘open’,
+    q: ‘You need someone who can own the whole build.’,
+    a: "Frontend, backend, database, cloud, auth, deploy, monitoring. All of it in one place, not split across contractors who don’t talk.",
+    tags: [‘full-stack’, ‘ownership’, ‘delivery’],
   },
   {
-    issue: 'ISSUE-004',
-    state: 'open',
-    q: 'You want AI leverage without AI chaos.',
-    a: "I use Claude, Cursor, and agent CLIs daily — but every output gets reviewed, tested, and architected by a human who’s been shipping for 8 years.",
-    tags: ['ai-assisted', 'review', 'judgment'],
+    issue: ‘ISSUE-004’,
+    state: ‘open’,
+    q: ‘You want AI leverage without AI chaos.’,
+    a: "I use Claude, Cursor, and agent CLIs every day. Every output still gets reviewed, tested, and shaped by someone who has been shipping for 8 years.",
+    tags: [‘ai-assisted’, ‘review’, ‘judgment’],
   },
 ]
 
@@ -49,7 +49,7 @@ export function FounderProblems() {
           <h2 className="section-title">Four problems I genuinely love solving.</h2>
         </div>
         <p className="section-sub">
-          These are the engineering challenges I gravitate toward — whether at work, in side projects, or collaborating with builders.
+          Problems I keep coming back to, at work and in my own builds.
         </p>
       </div>
       <div className="problems-grid">

--- a/src/components/FounderProblems.tsx
+++ b/src/components/FounderProblems.tsx
@@ -46,10 +46,10 @@ export function FounderProblems() {
             <span className="num">01 /</span> <span className="dot"></span>{' '}
             <span>where i help most</span>
           </div>
-          <h2 className="section-title">The four problems I get hired to solve.</h2>
+          <h2 className="section-title">Four problems I genuinely love solving.</h2>
         </div>
         <p className="section-sub">
-          Most founders I work with land on one of these. If any sound familiar, we should talk.
+          These are the engineering challenges I gravitate toward — whether at work, in side projects, or collaborating with builders.
         </p>
       </div>
       <div className="problems-grid">
@@ -58,7 +58,7 @@ export function FounderProblems() {
             <div className="problem-issue">
               <span>{p.issue}</span>
               <span className="badge">{p.state}</span>
-              <span style={{ marginLeft: 'auto' }}>· assigned: @meher</span>
+              <span style={{ marginLeft: 'auto' }}>· engineer: @meher</span>
             </div>
             <h3 className="problem-q">{p.q}</h3>
             <p className="problem-a">{p.a}</p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -12,19 +12,19 @@ type TermLine =
   | { kind: 'comment'; text: string }
 
 const TERM_SCRIPT: TermLine[] = [
-  { kind: 'cmd', text: 'founder build --with meher' },
+  { kind: 'cmd', text: 'engineer build --mode end-to-end' },
   { kind: 'blank' },
   { kind: 'kv', k: 'idea', v: 'rough product concept', color: '' },
-  { kind: 'arrow', text: 'running discovery...' },
+  { kind: 'arrow', text: 'running full-stack build...' },
   { kind: 'kv', k: 'spec', v: 'developer-ready scope + tasks', color: 'accent' },
   { kind: 'kv', k: 'stack', v: 'Next.js · NestJS · PostgreSQL · AWS', color: '' },
   { kind: 'kv', k: 'workflow', v: 'architect → build → review → ship', color: '' },
   { kind: 'kv', k: 'leverage', v: 'AI agents + CLI automation', color: 'accent' },
   { kind: 'kv', k: 'judgment', v: 'senior engineer (human-owned)', color: 'amber' },
   { kind: 'blank' },
-  { kind: 'ok', text: '✓ ready to ship — production hardened' },
+  { kind: 'ok', text: '✓ production hardened — 8+ years shipping' },
   { kind: 'blank' },
-  { kind: 'comment', text: '# 8+ years · KL, Malaysia · open for Q3 2026' },
+  { kind: 'comment', text: '# full-stack · KL, Malaysia · builder mindset' },
 ]
 
 function TerminalCard() {
@@ -87,11 +87,11 @@ function TerminalCard() {
         <span className="term-dot r"></span>
         <span className="term-dot y"></span>
         <span className="term-dot g"></span>
-        <span className="term-title">~/founder-build — zsh — 80×24</span>
+        <span className="term-title">~/build — zsh — 80×24</span>
       </div>
       <div className="term-tabs">
         <div className="term-tab active">
-          <Icon.terminal /> founder-build <span className="close">×</span>
+          <Icon.terminal /> engineer-build <span className="close">×</span>
         </div>
         <div className="term-tab">spec.md</div>
         <div className="term-tab">architecture.md</div>
@@ -158,20 +158,20 @@ export function Hero() {
         <div className="hero-copy">
           <div className="hero-eyebrow">
             <span className="pulse"></span>
-            <span>Senior engineer · Founder-friendly · KL, MY</span>
+            <span>Senior Software Engineer · Full-stack · KL, MY</span>
           </div>
           <h1>
-            I help founders turn <span className="accent">rough ideas</span> into{' '}
-            <span className="ul">production-ready software.</span>
+            I build <span className="accent">production-ready software</span> —{' '}
+            <span className="ul">end-to-end, from idea to shipped.</span>
           </h1>
           <p className="hero-sub">
             <strong>8+ years</strong> shipping scalable web apps, SaaS products, and AI workflows.
-            I work end-to-end — from spec and architecture to backend, frontend, and deployment —
-            so you can go from idea to launch with one technical partner.
+            I work across the full stack — spec, architecture, backend, frontend, and deployment —
+            with the ownership mindset of someone who cares how the product actually lands.
           </p>
           <div className="hero-cta">
             <a className="btn btn-primary" href="#contact">
-              Work with me <Icon.arrowRight />
+              Get in touch <Icon.arrowRight />
             </a>
             <a className="btn btn-ghost" href="#projects">
               View projects

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -22,7 +22,7 @@ const TERM_SCRIPT: TermLine[] = [
   { kind: 'kv', k: 'leverage', v: 'AI agents + CLI automation', color: 'accent' },
   { kind: 'kv', k: 'judgment', v: 'senior engineer (human-owned)', color: 'amber' },
   { kind: 'blank' },
-  { kind: 'ok', text: '✓ production hardened — 8+ years shipping' },
+  { kind: 'ok', text: '✓ production hardened, 8+ years shipping' },
   { kind: 'blank' },
   { kind: 'comment', text: '# full-stack · KL, Malaysia · builder mindset' },
 ]
@@ -161,13 +161,13 @@ export function Hero() {
             <span>Senior Software Engineer · Full-stack · KL, MY</span>
           </div>
           <h1>
-            I build <span className="accent">production-ready software</span> —{' '}
-            <span className="ul">end-to-end, from idea to shipped.</span>
+            I build <span className="accent">production-ready software.</span>{' '}
+            <span className="ul">End-to-end, from idea to shipped.</span>
           </h1>
           <p className="hero-sub">
-            <strong>8+ years</strong> shipping scalable web apps, SaaS products, and AI workflows.
-            I work across the full stack — spec, architecture, backend, frontend, and deployment —
-            with the ownership mindset of someone who cares how the product actually lands.
+            <strong>8+ years</strong> shipping web apps, SaaS products, and AI tooling.
+            I work across the full stack: spec, architecture, backend, frontend, deployment.
+            I care about how the product lands, not just that the code runs.
           </p>
           <div className="hero-cta">
             <a className="btn btn-primary" href="#contact">

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,14 +1,14 @@
 import { Icon } from '@/components/Icons'
 
 const SERVICES = [
-  { ico: <Icon.zap />, name: 'MVP development', desc: 'Idea → working product. 4–10 week sprints with weekly demos and a real launch at the end.' },
-  { ico: <Icon.layers />, name: 'SaaS product build', desc: 'Multi-tenant, billing, auth, dashboards. The non-glamorous backbone that paid SaaS needs.' },
-  { ico: <Icon.code />, name: 'Full-stack feature delivery', desc: 'Drop into an existing team and ship vertical slices — frontend, API, data, deploy.' },
-  { ico: <Icon.cpu />, name: 'Backend & API architecture', desc: 'Data model, contracts, jobs, queues. Designed to scale before scale is a problem.' },
-  { ico: <Icon.sparkle />, name: 'AI workflow integration', desc: 'Agents, RAG, CLI automation, prompt pipelines — integrated into your real codebase, not a demo.' },
-  { ico: <Icon.terminal />, name: 'Developer tooling & CLIs', desc: 'Internal tools, scripts, CLIs that make your team faster every week, not just once.' },
-  { ico: <Icon.target />, name: 'Technical planning', desc: 'Turning rough product ideas into engineering scope, milestones, and honest estimates.' },
-  { ico: <Icon.shield />, name: 'Production debugging', desc: 'Things on fire? I read logs, fix the root cause, and write the runbook so it doesn\'t repeat.' },
+  { ico: <Icon.zap />, name: 'MVP development', desc: 'Idea to working product. Weekly progress, real milestones, actual launch at the end.' },
+  { ico: <Icon.layers />, name: 'SaaS product build', desc: 'Multi-tenant, billing, auth, dashboards. The unglamorous backbone that paid SaaS actually needs.' },
+  { ico: <Icon.code />, name: 'Full-stack feature delivery', desc: 'Drop into an existing team and ship vertical slices: frontend, API, data, deploy.' },
+  { ico: <Icon.cpu />, name: 'Backend & API architecture', desc: 'Data model, contracts, jobs, queues. Built to scale before scale becomes the problem.' },
+  { ico: <Icon.sparkle />, name: 'AI workflow integration', desc: 'Agents, RAG, CLI automation, prompt pipelines. Integrated into a real codebase, not a demo.' },
+  { ico: <Icon.terminal />, name: 'Developer tooling & CLIs', desc: 'Internal tools, scripts, CLIs that save your team time every single week.' },
+  { ico: <Icon.target />, name: 'Technical planning', desc: 'Rough product idea turned into engineering scope, milestones, and honest estimates.' },
+  { ico: <Icon.shield />, name: 'Production debugging', desc: "Things on fire? I dig into logs, fix the root cause, and write the runbook so it doesn't happen again." },
 ]
 
 export function Services() {
@@ -23,7 +23,7 @@ export function Services() {
           <h2 className="section-title">Eight areas I focus on and enjoy building in.</h2>
         </div>
         <p className="section-sub">
-          These are the kinds of problems I work on day-to-day and explore in side projects — full-stack, AI workflows, and everything in between.
+          Things I work on daily and dig into in my own time. Full-stack, AI tooling, the whole build.
         </p>
       </div>
       <div className="services-grid">

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -20,11 +20,10 @@ export function Services() {
             <span className="num">04 /</span> <span className="dot"></span>{' '}
             <span>how i can help</span>
           </div>
-          <h2 className="section-title">Eight ways founders &amp; teams hire me.</h2>
+          <h2 className="section-title">Eight areas I focus on and enjoy building in.</h2>
         </div>
         <p className="section-sub">
-          Most engagements blend a few of these. Some are 4-week projects, some are 6-month
-          embedded partnerships.
+          These are the kinds of problems I work on day-to-day and explore in side projects — full-stack, AI workflows, and everything in between.
         </p>
       </div>
       <div className="services-grid">


### PR DESCRIPTION
## Summary

- **Hero**: Changed eyebrow to \"Senior Software Engineer · Full-stack\", reframed H1/sub to describe engineering approach (not a service offer), changed CTA from \"Work with me\" to \"Get in touch\", removed \"open for Q3 2026\" from terminal, renamed terminal command from `founder build --with meher` to `engineer build --mode end-to-end`
- **FounderProblems**: Section title changed from \"problems I get hired to solve\" → \"problems I genuinely love solving\"; sub-copy reframes as engineering interest rather than hire pitch; `assigned:` → `engineer:` label
- **Services**: Title changed from \"Eight ways founders & teams hire me\" → \"Eight areas I focus on and enjoy building in\"; removed engagement-length language (4-week projects, 6-month embedded partnerships)
- **Contact**: Terminal prompt `founder contact` → `engineer contact`; heading softened to \"Let's talk\"; body removes founder/startup/stalled-build framing

## Why

Current site reads as actively soliciting freelance/contract work, which can flag as moonlighting to an employer. These changes keep the builder/end-to-end identity but frame it as an engineering mindset and personal interest, not services for sale.

## Test plan

- [ ] Verify Hero eyebrow, H1, CTA text render correctly
- [ ] Verify terminal animation shows updated command and strips \"open for Q3\" line
- [ ] Verify FounderProblems section heading and sub updated
- [ ] Verify Services heading and sub updated
- [ ] Verify Contact heading, sub, and terminal prompt updated