### PR TITLE
Sync master to main: project updates, SE reposition, audit fixes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@ import { Hero } from '@/components/Hero'
 import { FounderProblems } from '@/components/FounderProblems'
 import { BuildProcess } from '@/components/BuildProcess'
 import { AgenticEngineering } from '@/components/AgenticEngineering'
-import { Services } from '@/components/Services'
 import { Projects } from '@/components/Projects'
 import { Experience } from '@/components/Experience'
 import { Skills } from '@/components/Skills'
@@ -17,7 +16,6 @@ export default function Home() {
       <FounderProblems />
       <BuildProcess />
       <AgenticEngineering />
-      <Services />
       <Projects />
       <Experience />
       <Skills />

--- a/src/components/AgenticEngineering.tsx
+++ b/src/components/AgenticEngineering.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 import { Icon } from '@/components/Icons'
 
 const AGENTS = [
-  { name: 'Founder Goal', role: 'the business outcome we\'re building toward', icon: <Icon.target />, status: 'input', type: '' },
+  { name: 'Product Goal', role: 'the outcome we are building toward', icon: <Icon.target />, status: 'input', type: '' },
   { name: 'Architect Agent', role: 'system design, data model, API boundaries', icon: <Icon.layers />, status: 'auto', type: '' },
   { name: 'Coder Agent', role: 'implements modules under defined contracts', icon: <Icon.builder />, status: 'auto', type: '' },
   { name: 'Reviewer Agent', role: 'static analysis, style, anti-patterns', icon: <Icon.reviewer />, status: 'auto', type: '' },
@@ -25,8 +25,7 @@ export function AgenticEngineering() {
           </h2>
         </div>
         <p className="section-sub">
-          I use AI agents and CLI workflows for leverage — never as autopilot. Founders get faster
-          delivery without losing the engineering quality that keeps a product alive in year two.
+          I use AI agents and CLI tools daily. They handle volume. I handle decisions. The output still has to meet the same bar as code I wrote by hand.
         </p>
       </div>
       <div className="agentic-grid">
@@ -53,44 +52,36 @@ export function AgenticEngineering() {
           ))}
         </div>
         <div className="agent-copy">
-          <h3>Speed without losing the plot.</h3>
+          <h3>Fast output, real standards.</h3>
           <p>
-            The AI handles the volume work — boilerplate, scaffolds, drafts, test stubs. I handle
-            the decisions that matter: what to build, how to structure it, what to refuse to build,
-            and when &ldquo;the agent&rsquo;s suggestion&rdquo; is actually a maintenance bomb six
-            months out.
+            AI handles the repetitive parts: boilerplate, scaffolds, test stubs, first drafts. I handle what actually requires thought: system design, security, trade-offs, and whether something should be built at all.
           </p>
           <p>
-            Founders don&rsquo;t need a pure prompter or a pure engineer. They need someone who can
-            hold both.
+            Code from an agent goes through the same review as code from anyone else. If I would not merge it from a junior engineer, I do not merge it from a model.
           </p>
           <div className="agent-principles">
             <div className="agent-principle">
               <span className="pn">01.</span>
               <span>
-                <strong>AI for speed,</strong> not for judgment. Architecture and trade-offs stay
-                human.
+                <strong>AI for repetitive work.</strong> Architecture and trade-offs stay human.
               </span>
             </div>
             <div className="agent-principle">
               <span className="pn">02.</span>
               <span>
-                <strong>Every output gets reviewed.</strong> If I wouldn&rsquo;t merge it from a
-                junior, I don&rsquo;t merge it from an agent.
+                <strong>Every output gets reviewed.</strong> Same bar as any other code review.
               </span>
             </div>
             <div className="agent-principle">
               <span className="pn">03.</span>
               <span>
-                <strong>Tests are the contract.</strong> Generated code earns trust the same way
-                human code does.
+                <strong>Tests are the contract.</strong> Generated code earns trust the same way hand-written code does.
               </span>
             </div>
             <div className="agent-principle">
               <span className="pn">04.</span>
               <span>
-                <strong>Boring works.</strong> Postgres, queues, monoliths — chosen on merit, not
-                novelty.
+                <strong>Boring is fine.</strong> Postgres, queues, monoliths. Chosen because they work, not because they are interesting.
               </span>
             </div>
           </div>

--- a/src/components/BuildProcess.tsx
+++ b/src/components/BuildProcess.tsx
@@ -28,7 +28,7 @@ export function BuildProcess() {
             <span>build process</span>
           </div>
           <h2 className="section-title">
-            From idea to shipped product — <em>without skipping steps.</em>
+            From idea to shipped product. <em>No steps skipped.</em>
           </h2>
         </div>
         <p className="section-sub">

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -3,10 +3,10 @@ const STATS = [
 ]
 
 const MISSIONS = [
-  { when: '2022 — now', what: 'Senior Software Engineer', where: 'Snappymob · Kuala Lumpur, Malaysia', status: 'active' },
+  { when: '2022 - now', what: 'Senior Software Engineer', where: 'Snappymob · Kuala Lumpur, Malaysia', status: 'active' },
   { when: '2022', what: 'PHP Developer', where: 'Wipro Bangladesh Limited · Dhaka', status: 'done' },
-  { when: '2019 — 2022', what: 'Software Developer', where: 'SCT-Bangla Limited · Dhaka', status: 'done' },
-  { when: '2017 — 2019', what: 'Full-Stack Web Developer', where: 'Bangladesh Software Development (BSD) · Dhaka', status: 'done' },
+  { when: '2019 - 2022', what: 'Software Developer', where: 'SCT-Bangla Limited · Dhaka', status: 'done' },
+  { when: '2017 - 2019', what: 'Full-Stack Web Developer', where: 'Bangladesh Software Development (BSD) · Dhaka', status: 'done' },
 ]
 
 export function Experience() {
@@ -23,8 +23,7 @@ export function Experience() {
           </h2>
         </div>
         <p className="section-sub">
-          Enterprise systems, SaaS products, and internal tools — owned end-to-end across frontend,
-          backend, and infrastructure.
+          Enterprise systems, SaaS products, and internal tools. Frontend, backend, and infrastructure.
         </p>
       </div>
       <div className="experience-grid">

--- a/src/components/FounderProblems.tsx
+++ b/src/components/FounderProblems.tsx
@@ -10,30 +10,30 @@ const PROBLEMS: Problem[] = [
   {
     issue: 'ISSUE-001',
     state: 'open',
-    q: 'You have an idea but no technical roadmap.',
-    a: 'I turn rough product concepts into clear specs, system architecture, and an MVP plan you can actually ship. No 6-week discovery process.',
-    tags: ['discovery', 'specs', 'architecture'],
+    q: 'Requirements exist but no one has turned them into a technical plan.',
+    a: 'I take written requirements, user stories, or rough notes and produce a real technical roadmap: data model, API design, infra decisions, milestones, and task breakdown. Something engineers can actually build from.',
+    tags: ['roadmap', 'specs', 'architecture'],
   },
   {
     issue: 'ISSUE-002',
     state: 'open',
-    q: 'Your MVP is slow, messy, or hard to extend.',
-    a: 'I refactor full-stack codebases, stabilise CI/CD, fix the data model, and get the system back to a place where adding features is fast again.',
-    tags: ['refactor', 'stability', 'speed'],
+    q: 'The existing codebase is too slow, brittle, or hard to extend.',
+    a: 'I dig into the code, find what is actually causing the problem, and fix it. Query performance, deployment pipeline, flaky data model, tight coupling. I refactor until adding a new feature does not feel like defusing a bomb.',
+    tags: ['refactor', 'performance', 'deployment'],
   },
   {
     issue: 'ISSUE-003',
     state: 'open',
-    q: 'You need someone who can own the whole build.',
-    a: "Frontend, backend, database, cloud, auth, deploy, monitoring. All of it in one place, not split across contractors who don't talk.",
-    tags: ['full-stack', 'ownership', 'delivery'],
+    q: 'Something needs to be built from scratch and shipped to production.',
+    a: 'I handle the whole thing. Architecture, backend, frontend, auth, database, CI/CD, deployment, monitoring. I have done this enough times to know where projects stall and how to avoid it.',
+    tags: ['full-stack', 'build', 'deployment'],
   },
   {
     issue: 'ISSUE-004',
     state: 'open',
-    q: 'You want AI leverage without AI chaos.',
-    a: "I use Claude, Cursor, and agent CLIs every day. Every output still gets reviewed, tested, and shaped by someone who has been shipping for 8 years.",
-    tags: ['ai-assisted', 'review', 'judgment'],
+    q: 'The team wants to use AI but is not sure how to do it properly.',
+    a: 'I work with Claude, Cursor, and agent tooling every day on real production code. I know what AI is good at, where it cuts corners, and how to set up workflows that make the whole team faster without creating a mess.',
+    tags: ['ai-tooling', 'workflow', 'code-quality'],
   },
 ]
 
@@ -46,10 +46,10 @@ export function FounderProblems() {
             <span className="num">01 /</span> <span className="dot"></span>{' '}
             <span>where i help most</span>
           </div>
-          <h2 className="section-title">Four problems I genuinely love solving.</h2>
+          <h2 className="section-title">Four things I do well and do often.</h2>
         </div>
         <p className="section-sub">
-          Problems I keep coming back to, at work and in my own builds.
+          Problems I run into constantly, at work and in side projects. I have good answers for all of them.
         </p>
       </div>
       <div className="problems-grid">

--- a/src/components/GitHubDashboard.tsx
+++ b/src/components/GitHubDashboard.tsx
@@ -1,36 +1,5 @@
 import { Icon } from '@/components/Icons'
 
-const REPOS = [
-  {
-    name: 'aiagentflow.dev',
-    desc: 'Site & resources for the aiagentflow project — agentic engineering workflows.',
-    lang: 'TypeScript',
-    langColor: '#3178c6',
-    href: 'https://github.com/raj-khan/aiagentflow.dev',
-  },
-  {
-    name: 'nextjs-supabase-saas-boilerplate',
-    desc: 'Reusable architecture, coding-agent workflow, and engineering conventions for Next.js + Supabase SaaS projects.',
-    lang: 'TypeScript',
-    langColor: '#3178c6',
-    href: 'https://github.com/raj-khan/nextjs-supabase-saas-boilerplate',
-  },
-  {
-    name: 'pre-school-keyboard',
-    desc: 'A playful browser typing game for one child — large keys, voice feedback, and friendly emoji reactions.',
-    lang: 'TypeScript',
-    langColor: '#3178c6',
-    href: 'https://github.com/raj-khan/pre-school-keyboard',
-  },
-  {
-    name: 'meher-jq',
-    desc: 'Command-line JSON processor — exploration of jq-style filtering in C.',
-    lang: 'C',
-    langColor: '#555555',
-    href: 'https://github.com/raj-khan/meher-jq',
-  },
-]
-
 export function GitHubDashboard() {
   return (
     <section className="section container reveal" id="github">
@@ -41,12 +10,11 @@ export function GitHubDashboard() {
             <span>open source</span>
           </div>
           <h2 className="section-title">
-            I build &amp; experiment <em>in public.</em>
+            Most of my work is <em>on GitHub.</em>
           </h2>
         </div>
         <p className="section-sub">
-          A few public repos around AI-assisted engineering, CLI tools, and developer workflows.
-          Most client work lives in private repos — these are the ones you can read.
+          Client work is private. Side projects, CLI tools, and experiments are public. See the projects section above for details.
         </p>
       </div>
       <div className="gh-card">
@@ -60,27 +28,31 @@ export function GitHubDashboard() {
             rel="noopener"
             style={{ marginLeft: 'auto', textDecoration: 'none', color: 'inherit' }}
           >
-            github.com/raj-khan →
+            github.com/raj-khan
           </a>
         </div>
         <div className="gh-body">
           <div className="gh-repos">
-            {REPOS.map((r) => (
-              <a className="gh-repo" key={r.name} href={r.href} target="_blank" rel="noopener">
-                <div className="gh-repo-name">
-                  <Icon.folder />
-                  <span>{r.name}</span>
-                  <span className="pub">public</span>
-                </div>
-                <div className="gh-repo-desc">{r.desc}</div>
-                <div className="gh-repo-meta">
-                  <span>
-                    <span className="lang-dot" style={{ background: r.langColor }}></span>
-                    {r.lang}
-                  </span>
-                </div>
-              </a>
-            ))}
+            <a className="gh-repo" href="https://github.com/raj-khan" target="_blank" rel="noopener">
+              <div className="gh-repo-name">
+                <Icon.github />
+                <span>View all public repos</span>
+              </div>
+              <div className="gh-repo-desc">TypeScript, Node.js, Ruby, React. CLI tools, SaaS starters, and side projects.</div>
+              <div className="gh-repo-meta">
+                <span>github.com/raj-khan</span>
+              </div>
+            </a>
+            <a className="gh-repo" href="https://github.com/aiagentflow" target="_blank" rel="noopener">
+              <div className="gh-repo-name">
+                <Icon.github />
+                <span>aiagentflow org</span>
+              </div>
+              <div className="gh-repo-desc">Multi-agent AI workflow tooling for software development.</div>
+              <div className="gh-repo-meta">
+                <span>github.com/aiagentflow</span>
+              </div>
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -87,7 +87,7 @@ function TerminalCard() {
         <span className="term-dot r"></span>
         <span className="term-dot y"></span>
         <span className="term-dot g"></span>
-        <span className="term-title">~/build — zsh — 80×24</span>
+        <span className="term-title">~/build · zsh · 80×24</span>
       </div>
       <div className="term-tabs">
         <div className="term-tab active">

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -12,36 +12,52 @@ type Project = {
 
 const PROJECTS: Project[] = [
   {
-    name: 'raj-khan/aiagentflow.dev',
-    badge: 'public',
-    tagline: 'Site & resources for the aiagentflow project — agentic engineering workflows.',
-    about: 'Documentation and resources for orchestrating multi-agent software engineering with structured pipelines, checkpoints, and review.',
-    stack: ['TypeScript', 'Next.js', 'Agentic'],
-    links: [{ label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan/aiagentflow.dev' }],
+    name: 'aiagentflow/cli',
+    badge: 'open source',
+    tagline: 'CLI tool that orchestrates multi-agent AI workflows for software development.',
+    about: 'Command-line tool for running structured multi-agent pipelines. Handles task routing, agent handoffs, and output validation so AI-assisted dev stays predictable.',
+    stack: ['Node.js', 'TypeScript', 'Commander.js', 'Vitest'],
+    links: [
+      { label: 'github', icon: <Icon.github />, href: 'https://github.com/aiagentflow' },
+      { label: 'aiagentflow.dev', icon: <Icon.external />, href: 'https://aiagentflow.dev' },
+    ],
+  },
+  {
+    name: 'raj-khan/e2spec',
+    badge: 'open source',
+    tagline: 'Turns project estimates into structured development specs and LLM-ready prompts.',
+    about: 'Ruby CLI that takes rough project estimates and outputs structured specs, implementation plans, and prompts ready to drop into any LLM. Built on the OpenAI API.',
+    stack: ['Ruby', 'OpenAI API', 'CLI'],
+    links: [
+      { label: 'e2spec.com', icon: <Icon.external />, href: 'https://e2spec.com' },
+    ],
+  },
+  {
+    name: 'raj-khan/seorankslab',
+    badge: 'open source',
+    tagline: 'Turns Search Console data into prioritized SEO tasks and AI-ready prompts.',
+    about: 'Connects to Google Search Console and scores your pages deterministically in code. Outputs weekly reports and prompts you can hand to an LLM. GSC data never leaves your machine.',
+    stack: ['Next.js', 'TypeScript', 'Supabase', 'Tailwind CSS'],
+    links: [
+      { label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan/seorankslab' },
+      { label: 'seorankslab.com', icon: <Icon.external />, href: 'https://seorankslab.com' },
+    ],
   },
   {
     name: 'raj-khan/nextjs-supabase-saas-boilerplate',
     badge: 'public',
     tagline: 'Reusable architecture and engineering conventions for Next.js + Supabase SaaS.',
-    about: 'Coding-agent workflow, repo structure, and opinionated conventions I reach for when starting a new SaaS — auth, database, and deploy patterns included.',
+    about: 'Repo structure, auth, database, and deploy patterns I reach for when starting a new SaaS. Opinionated but lightweight.',
     stack: ['TypeScript', 'Next.js', 'Supabase', 'SaaS'],
     links: [{ label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan/nextjs-supabase-saas-boilerplate' }],
   },
   {
     name: 'raj-khan/pre-school-keyboard',
     badge: 'public',
-    tagline: 'A playful browser typing game built for one child — large keys, voice feedback, emoji reactions.',
-    about: 'Built for my own kid. Each key press shows the character in large text, speaks it aloud, changes colors, and shows a friendly emoji. A small project that taught me a lot about input latency and audio cues.',
+    tagline: 'A browser typing game built for one kid. Large keys, voice feedback, emoji reactions.',
+    about: 'Built for my own kid. Each key press shows the character in large text, speaks it aloud, changes colors, and shows a friendly emoji. Taught me a lot about input latency and audio cues.',
     stack: ['TypeScript', 'Web Audio', 'React'],
     links: [{ label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan/pre-school-keyboard' }],
-  },
-  {
-    name: 'raj-khan/meher-jq',
-    badge: 'public',
-    tagline: 'Command-line JSON processor — a jq-style tool written from scratch in C.',
-    about: 'Exploration of how jq-style streaming JSON filtering works under the hood — built for learning, not as a jq replacement.',
-    stack: ['C', 'CLI', 'JSON'],
-    links: [{ label: 'github', icon: <Icon.github />, href: 'https://github.com/raj-khan/meher-jq' }],
   },
 ]
 
@@ -55,12 +71,11 @@ export function Projects() {
             <span>build artifacts</span>
           </div>
           <h2 className="section-title">
-            Public work — <em>code you can read.</em>
+            Public work. <em>Code you can read.</em>
           </h2>
         </div>
         <p className="section-sub">
-          A few open repos. Most client work is private — these are the projects with public code
-          to look at.
+          A few open repos. Most client work is private. These are the projects with public code.
         </p>
       </div>
       <div className="projects-grid">

--- a/src/components/Writing.tsx
+++ b/src/components/Writing.tsx
@@ -16,7 +16,7 @@ export function Writing() {
             <span>engineering notes</span>
           </div>
           <h2 className="section-title">
-            Writing — <em>practical, not promotional.</em>
+            Writing. <em>Practical, not promotional.</em>
           </h2>
         </div>
         <p className="section-sub">


### PR DESCRIPTION
Syncs all recent changes from master to main for deployment.

Includes:
- Removed Services section (duplicate of FounderProblems)
- Updated projects list (aiAgentFlow, e2Spec, SEO Ranks Lab, removed meher-jq)
- Simplified GitHubDashboard to profile links only
- Rephrased FounderProblems cards to reflect real capabilities
- AgenticEngineering: removed founder framing and buzzwords
- Fixed all em dashes site-wide
- Smart quote build fix from PR #19